### PR TITLE
Add structured JSONL logging with experiment step journal

### DIFF
--- a/back/rapidboxes/config.py
+++ b/back/rapidboxes/config.py
@@ -56,9 +56,13 @@ class AppConfig(BaseSettings):
     # Live preview (MJPEG) target frame rate.
     preview_fps: float = 5.0
 
+    # Where structured JSONL logs (errors, experiment journal, system) are written.
+    log_root: Path = Path.home() / "rapidboxes" / "logs"
+
     def ensure_dirs(self) -> None:
         self.storage_root.mkdir(parents=True, exist_ok=True)
         self.settings_path.parent.mkdir(parents=True, exist_ok=True)
+        self.log_root.mkdir(parents=True, exist_ok=True)
 
 
 @lru_cache

--- a/back/rapidboxes/engine/runner.py
+++ b/back/rapidboxes/engine/runner.py
@@ -25,6 +25,14 @@ from ..models import (
     StartResponse,
     TropismConfig,
 )
+from ..logging import (
+    clear_experiment_context,
+    journal_step,
+    log_error,
+    reset_step_index,
+    set_experiment_context,
+    set_phase,
+)
 from ..storage import ExperimentDir, Storage
 from .scheduler import advance_deadline, planned_captures
 
@@ -151,35 +159,52 @@ class ExperimentRunner:
 
     async def start(self, config: Config, camera: Optional[CameraSettings] = None) -> StartResponse:
         if self.status.state in (ExperimentState.running, ExperimentState.paused, ExperimentState.finishing):
+            journal_step("experiment.start", "skipped", detail="busy")
             return StartResponse(status="busy", experimentId=self.status.experimentId)
         if not self._hw.camera_available:
+            journal_step("experiment.start", "crashed", error="no_camera")
+            log_error("experiment", "start_failed", "camera not available", reason="no_camera")
             return StartResponse(status="no_camera")
+
+        journal_step("experiment.start", "started", detail=f"protocol={config.protocol}")
         exp = self._storage.create_experiment(config.username, config.experimentName)
         self._exp_dir = exp
-        if isinstance(config, TropismConfig):
-            saved = SavedExperimentConfig(
-                protocol="tropism",
-                darkPhaseEnabled=config.darkPhaseEnabled,
-                darkPhaseHours=config.darkPhaseHours,
-                lateralIlluminationHours=config.lateralIlluminationHours,
-                spectra=config.spectra,
-                intervalMinutes=config.intervalMinutes,
-                intensity=config.intensity,
-                camera=camera or CameraSettings(),
-            )
-            exp.write_config_xml(config_xml.serialize(saved), config.experimentName)
-        else:
-            saved = SavedExperimentConfig(
-                protocol="growth",
-                spectra=config.spectra,
-                intervalMinutes=config.intervalMinutes,
-                dayLengthHours=config.dayLengthHours,
-                experimentLengthDays=config.experimentLengthDays,
-                dayIntensity=config.dayIntensity,
-                photoIlluminationSource=config.photoIlluminationSource,
-                camera=camera or CameraSettings(),
-            )
-            exp.write_config_xml(config_xml.serialize(saved), config.experimentName)
+        reset_step_index()
+        set_experiment_context(exp.experiment_id, protocol=config.protocol)
+        journal_step("experiment.create_dir", "done", detail=str(exp.path))
+
+        try:
+            if isinstance(config, TropismConfig):
+                saved = SavedExperimentConfig(
+                    protocol="tropism",
+                    darkPhaseEnabled=config.darkPhaseEnabled,
+                    darkPhaseHours=config.darkPhaseHours,
+                    lateralIlluminationHours=config.lateralIlluminationHours,
+                    spectra=config.spectra,
+                    intervalMinutes=config.intervalMinutes,
+                    intensity=config.intensity,
+                    camera=camera or CameraSettings(),
+                )
+                exp.write_config_xml(config_xml.serialize(saved), config.experimentName)
+            else:
+                saved = SavedExperimentConfig(
+                    protocol="growth",
+                    spectra=config.spectra,
+                    intervalMinutes=config.intervalMinutes,
+                    dayLengthHours=config.dayLengthHours,
+                    experimentLengthDays=config.experimentLengthDays,
+                    dayIntensity=config.dayIntensity,
+                    photoIlluminationSource=config.photoIlluminationSource,
+                    camera=camera or CameraSettings(),
+                )
+                exp.write_config_xml(config_xml.serialize(saved), config.experimentName)
+            journal_step("experiment.write_xml", "done")
+        except Exception as exc:
+            journal_step("experiment.write_xml", "crashed", error=str(exc))
+            log_error("experiment", "write_xml_failed", str(exc), exc=exc, experiment_id=exp.experiment_id)
+            clear_experiment_context()
+            raise
+
         self._stop = False
         self._pause_event.set()
         self._clock = PausableClock(self._now)
@@ -200,6 +225,7 @@ class ExperimentRunner:
             self._clock.pause()
             self._pause_event.clear()
             self.status.state = ExperimentState.paused
+            journal_step("experiment.pause", "done")
             await self._broadcast()
 
     async def resume(self) -> None:
@@ -207,17 +233,20 @@ class ExperimentRunner:
             self._clock.resume()
             self._pause_event.set()
             self.status.state = ExperimentState.running
+            journal_step("experiment.resume", "done")
             await self._broadcast()
 
     async def stop(self) -> None:
         if self.status.state in (ExperimentState.running, ExperimentState.paused):
+            journal_step("experiment.stop", "started")
             self._stop = True
             self._pause_event.set()  # unblock if paused
             if self._task:
                 try:
                     await self._task
-                except Exception:
+                except Exception as exc:
                     log.exception("experiment task error during stop")
+                    log_error("experiment", "stop_task_error", str(exc), exc=exc)
 
     async def shutdown(self) -> None:
         """Called on app shutdown: stop the run and release hardware."""
@@ -229,9 +258,18 @@ class ExperimentRunner:
         latest = self._storage.latest_experiment()
         meta = latest.read_metadata() if latest else None
         if meta and meta.get("state") in ("running", "paused"):
+            msg = f"Previous experiment '{latest.experiment_id}' was interrupted and did not finish."
+            journal_step(
+                "experiment.recover",
+                "crashed",
+                error="interrupted_previous_run",
+                detail=msg,
+                experiment_id=latest.experiment_id,
+            )
+            log_error("experiment", "recover_interrupted", msg, experiment_id=latest.experiment_id)
             self.status = ExperimentStatus(
                 state=ExperimentState.idle,
-                message=f"Previous experiment '{latest.experiment_id}' was interrupted and did not finish.",
+                message=msg,
             )
 
     # --- run loop -------------------------------------------------------
@@ -246,9 +284,12 @@ class ExperimentRunner:
         if is_growth:
             self.status.imagesPlanned += 1  # one-off baseline photo
         try:
+            journal_step("experiment.configure_camera", "started")
             await self._hw.configure_camera()
+            journal_step("experiment.configure_camera", "done")
             if is_growth:
                 self.status.phase = ExperimentPhase.baseline
+                set_phase(ExperimentPhase.baseline.value)
                 await self._capture(ExperimentPhase.baseline, "baseline", config, exp)
             for phase in phases:
                 if self._stop:
@@ -256,34 +297,61 @@ class ExperimentRunner:
                 await self._run_phase(phase, interval_s, config, exp)
             self.status.message = "stopped by user" if self._stop else "completed"
             self.status.state = ExperimentState.done
+            journal_step(
+                "experiment.finalize",
+                "stopped" if self._stop else "done",
+                detail=self.status.message,
+            )
         except asyncio.CancelledError:
             self.status.state = ExperimentState.error
             self.status.message = "cancelled"
+            journal_step("experiment.finalize", "crashed", error="cancelled")
             raise
         except Exception as e:  # pragma: no cover - defensive
             log.exception("experiment failed")
+            log_error("experiment", "run_failed", str(e), exc=e)
             self.status.state = ExperimentState.error
             self.status.message = str(e)
+            journal_step("experiment.finalize", "crashed", error=str(e))
         finally:
             self.status.phase = None
             self.status.nextCaptureInSeconds = None
+            set_phase(None)
+            journal_step("experiment.cleanup", "started")
             try:
                 await self._hw.all_off()
-            except Exception:
+                journal_step("experiment.cleanup", "done")
+            except Exception as exc:
                 log.exception("all_off in finally failed")
+                journal_step("experiment.cleanup", "crashed", error=str(exc))
+                log_error("hardware", "cleanup_all_off_failed", str(exc), exc=exc)
             self._write_metadata(exp)
             await self._broadcast()
+            clear_experiment_context()
 
     async def _run_phase(
         self, phase: _Phase, interval_s: float, config: Config, exp: ExperimentDir
     ) -> None:
         assert self._clock is not None
+        phase_name = phase.name.value
+        step_prefix = f"phase.{phase_name}"
         self.status.phase = phase.name
+        set_phase(phase_name)
         self.status.phaseTotalSeconds = phase.duration_s
         self.status.dayIndex = phase.day_index
         self.status.totalDays = config.experimentLengthDays if isinstance(config, GrowthConfig) else None
+        journal_step(
+            step_prefix,
+            "started",
+            detail=f"duration_s={phase.duration_s}, day_index={phase.day_index}",
+        )
         phase_start = self._clock.elapsed()
-        await self._enter_phase_lights(phase, config)
+        try:
+            await self._enter_phase_lights(phase, config)
+        except Exception as exc:
+            journal_step(step_prefix, "crashed", error=f"enter_lights: {exc}")
+            log_error("hardware", "enter_phase_lights_failed", str(exc), exc=exc, phase=phase_name)
+            raise
         self._write_metadata(exp)
 
         next_cap: Optional[float] = 0.0 if phase.capture else None
@@ -306,6 +374,15 @@ class ExperimentRunner:
                         phase.name.value,
                         skipped,
                     )
+                    log_error(
+                        "experiment",
+                        "capture_overrun",
+                        f"skipped {skipped} capture slot(s)",
+                        level="WARNING",
+                        fsync=False,
+                        phase=phase_name,
+                        skipped_slots=skipped,
+                    )
             if phase.capture and next_cap is not None:
                 target = min(next_cap, phase.duration_s)
                 self.status.nextCaptureInSeconds = max(0.0, next_cap - (self._clock.elapsed() - phase_start))
@@ -316,7 +393,12 @@ class ExperimentRunner:
             remaining = target - (self._clock.elapsed() - phase_start)
             await self._sleep(max(0.0, min(remaining, self._tick)))
 
-        await self._hw.all_off()
+        try:
+            await self._hw.all_off()
+        except Exception as exc:
+            log_error("hardware", "phase_all_off_failed", str(exc), exc=exc, phase=phase_name)
+            raise
+        journal_step(step_prefix, "done" if not self._stop else "stopped")
 
     async def _enter_phase_lights(self, phase: _Phase, config: Config) -> None:
         if phase.name == ExperimentPhase.dark:
@@ -332,41 +414,58 @@ class ExperimentRunner:
         self, phase_name: ExperimentPhase, mode: Optional[str], config: Config, exp: ExperimentDir
     ) -> None:
         idx = self.status.imagesCaptured
+        step_id = f"phase.{phase_name.value}.capture.{idx}"
         path, image_id = exp.image_path(phase_name.value, idx)
-        if mode in ("dark", "baseline"):
-            await self._hw.ir_on()
-            try:
-                await self._hw.capture(str(path))
-            finally:
-                await self._hw.ir_off()
-        elif mode == "bending":
-            await self._hw.leds_off()  # lights off during the exposure
-            try:
-                await self._hw.capture(str(path))
-            finally:
-                await self._hw.lateral(config.spectra, config.intensity)  # back on for the interval
-        elif mode == "night":
-            if config.photoIlluminationSource == "ir":
+        journal_step(step_id, "started", detail=f"mode={mode}, path={path.name}")
+        try:
+            if mode in ("dark", "baseline"):
                 await self._hw.ir_on()
                 try:
                     await self._hw.capture(str(path))
                 finally:
                     await self._hw.ir_off()
-            else:  # rgbw: fixed-intensity top-down white flash, off again after
-                await self._hw.top_white(GROWTH_PHOTO_FLASH_INTENSITY)
+            elif mode == "bending":
+                await self._hw.leds_off()  # lights off during the exposure
                 try:
                     await self._hw.capture(str(path))
                 finally:
-                    await self._hw.all_off()
-        else:
-            await self._hw.capture(str(path))  # "day": ambient light, no flash
+                    await self._hw.lateral(config.spectra, config.intensity)  # back on for the interval
+            elif mode == "night":
+                if config.photoIlluminationSource == "ir":
+                    await self._hw.ir_on()
+                    try:
+                        await self._hw.capture(str(path))
+                    finally:
+                        await self._hw.ir_off()
+                else:  # rgbw: fixed-intensity top-down white flash, off again after
+                    await self._hw.top_white(GROWTH_PHOTO_FLASH_INTENSITY)
+                    try:
+                        await self._hw.capture(str(path))
+                    finally:
+                        await self._hw.all_off()
+            else:
+                await self._hw.capture(str(path))  # "day": ambient light, no flash
+        except Exception as exc:
+            journal_step(step_id, "crashed", error=str(exc))
+            log_error(
+                "hardware.camera",
+                "capture_failed",
+                str(exc),
+                exc=exc,
+                phase=phase_name.value,
+                capture_index=idx,
+                image_id=image_id,
+            )
+            raise
         self.status.imagesCaptured = idx + 1
         self.status.lastImageId = image_id
+        journal_step(step_id, "done", detail=image_id)
         self._write_metadata(exp)
         await self._broadcast()
 
     def _write_metadata(self, exp: ExperimentDir) -> None:
         try:
             exp.write_metadata(self.status.model_dump(mode="json"))
-        except Exception:
+        except Exception as exc:
             log.exception("metadata write failed")
+            log_error("storage", "metadata_write_failed", str(exc), exc=exc, experiment_id=exp.experiment_id)

--- a/back/rapidboxes/hardware/manager.py
+++ b/back/rapidboxes/hardware/manager.py
@@ -10,6 +10,8 @@ import asyncio
 import logging
 from typing import List
 
+from ..logging import log_error, log_system
+
 from ..config import AppConfig
 from ..models import CameraSettings, DeviceSettings
 from .base import (
@@ -63,13 +65,15 @@ class HardwareManager:
         """Best-effort: turn everything off, then release devices. Never raises."""
         try:
             await self.all_off()
-        except Exception:
+        except Exception as exc:
             log.exception("all_off during shutdown failed")
+            log_error("hardware", "shutdown_all_off_failed", str(exc), exc=exc)
         for closer in (self._leds.close, self._ir.close, self._camera.close):
             try:
                 await self._run(closer)
-            except Exception:
+            except Exception as exc:
                 log.exception("device close failed")
+                log_error("hardware", "device_close_failed", str(exc), exc=exc, device=closer.__name__)
 
     # --- camera ----------------------------------------------------------
     async def capture(self, path: str) -> None:
@@ -163,6 +167,7 @@ def build_hardware(config: AppConfig, settings: DeviceSettings) -> HardwareManag
         from .simulation import SimCamera, SimIr, SimLeds
 
         log.info("hardware: SIMULATION mode")
+        log_system("hardware.mode", "simulation backends active")
         camera: CameraBackend = SimCamera()
         leds: LedBackend = SimLeds(settings.leds.pixelCount)
         ir: IrBackend = SimIr()
@@ -172,10 +177,18 @@ def build_hardware(config: AppConfig, settings: DeviceSettings) -> HardwareManag
         from .leds import NeoPixelSpiLeds
 
         log.info("hardware: REAL device mode")
+        log_system("hardware.mode", "real device backends active")
         try:
             camera = Picamera2Camera()
         except CameraUnavailableError:
             log.warning("no camera detected; continuing without it (capture disabled)")
+            log_error(
+                "hardware.camera",
+                "camera_unavailable",
+                "no camera detected at startup",
+                level="WARNING",
+                fsync=False,
+            )
             camera = NullCamera()
             camera_available = False
         leds = NeoPixelSpiLeds(settings.leds)

--- a/back/rapidboxes/logging/__init__.py
+++ b/back/rapidboxes/logging/__init__.py
@@ -1,0 +1,24 @@
+"""Structured logging for RaPiD-boxes: errors, experiment journal, system events.
+
+All records are written as JSON Lines under the configured log root. Call
+``init_logging`` once at process startup (see ``main.py`` lifespan).
+"""
+from __future__ import annotations
+
+from .context import clear_experiment_context, reset_step_index, set_experiment_context, set_phase
+from .error_log import log_error
+from .experiment_journal import journal_step
+from .setup import init_logging, shutdown_logging
+from .system_log import log_system
+
+__all__ = [
+    "init_logging",
+    "shutdown_logging",
+    "log_error",
+    "journal_step",
+    "log_system",
+    "set_experiment_context",
+    "clear_experiment_context",
+    "reset_step_index",
+    "set_phase",
+]

--- a/back/rapidboxes/logging/context.py
+++ b/back/rapidboxes/logging/context.py
@@ -1,0 +1,71 @@
+"""Correlation context carried on every log record (run, experiment, phase)."""
+from __future__ import annotations
+
+import uuid
+from contextvars import ContextVar
+from typing import Any, Dict, Optional
+
+_run_id: ContextVar[str] = ContextVar("run_id", default="")
+_experiment_id: ContextVar[Optional[str]] = ContextVar("experiment_id", default=None)
+_protocol: ContextVar[Optional[str]] = ContextVar("protocol", default=None)
+_phase: ContextVar[Optional[str]] = ContextVar("phase", default=None)
+_step_index: ContextVar[int] = ContextVar("step_index", default=0)
+
+
+def new_run_id() -> str:
+    return str(uuid.uuid4())
+
+
+def set_run_id(run_id: str) -> None:
+    _run_id.set(run_id)
+
+
+def get_run_id() -> str:
+    return _run_id.get()
+
+
+def set_experiment_context(
+    experiment_id: Optional[str],
+    *,
+    protocol: Optional[str] = None,
+    phase: Optional[str] = None,
+) -> None:
+    _experiment_id.set(experiment_id)
+    if protocol is not None:
+        _protocol.set(protocol)
+    if phase is not None:
+        _phase.set(phase)
+
+
+def clear_experiment_context() -> None:
+    _experiment_id.set(None)
+    _protocol.set(None)
+    _phase.set(None)
+
+
+def set_phase(phase: Optional[str]) -> None:
+    _phase.set(phase)
+
+
+def next_step_index() -> int:
+    idx = _step_index.get() + 1
+    _step_index.set(idx)
+    return idx
+
+
+def reset_step_index() -> None:
+    _step_index.set(0)
+
+
+def base_fields() -> Dict[str, Any]:
+    out: Dict[str, Any] = {"run_id": get_run_id()}
+    exp = _experiment_id.get()
+    if exp:
+        out["experiment_id"] = exp
+    proto = _protocol.get()
+    if proto:
+        out["protocol"] = proto
+    phase = _phase.get()
+    if phase:
+        out["phase"] = phase
+    return out

--- a/back/rapidboxes/logging/error_log.py
+++ b/back/rapidboxes/logging/error_log.py
@@ -1,0 +1,65 @@
+"""Structured error records (errors.jsonl)."""
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any, Dict, Optional
+
+from .. import __version__
+from .context import base_fields
+from .jsonl import exception_fields, utc_now_iso
+from .writers import get_errors_writer
+
+log = logging.getLogger("rapidboxes.log")
+
+
+def _caller_where(skip: int = 2) -> Dict[str, Any]:
+    frame = inspect.currentframe()
+    for _ in range(skip):
+        if frame is None:
+            break
+        frame = frame.f_back
+    if frame is None:
+        return {}
+    return {
+        "module": frame.f_globals.get("__name__", ""),
+        "function": frame.f_code.co_name,
+        "line": frame.f_lineno,
+        "pathname": frame.f_code.co_filename,
+    }
+
+
+def log_error(
+    category: str,
+    event: str,
+    message: str,
+    *,
+    exc: Optional[BaseException] = None,
+    level: str = "ERROR",
+    where: Optional[Dict[str, Any]] = None,
+    fsync: bool = True,
+    **context: Any,
+) -> None:
+    """Write a structured error entry. Also emits a stdlib log line."""
+    writer = get_errors_writer()
+    record: Dict[str, Any] = {
+        "ts": utc_now_iso(),
+        "level": level,
+        "category": category,
+        "event": event,
+        "message": message,
+        "where": where or _caller_where(),
+        "context": context or None,
+        "software_version": __version__,
+        **base_fields(),
+    }
+    exc_fields = exception_fields(exc)
+    if exc_fields:
+        record["exception"] = exc_fields
+    if writer is not None:
+        try:
+            writer.write(record, fsync=fsync)
+        except Exception:
+            log.exception("failed to write error log record")
+    stdlib_level = getattr(logging, level, logging.ERROR)
+    log.log(stdlib_level, "[%s] %s: %s", category, event, message, exc_info=exc)

--- a/back/rapidboxes/logging/experiment_journal.py
+++ b/back/rapidboxes/logging/experiment_journal.py
@@ -1,0 +1,52 @@
+"""Experiment step journal (experiment.jsonl)."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from .. import __version__
+from .context import base_fields, next_step_index
+from .jsonl import utc_now_iso
+from .writers import get_journal_writer
+
+log = logging.getLogger("rapidboxes.journal")
+
+VALID_STATUSES = frozenset({"started", "done", "stopped", "crashed", "skipped"})
+
+
+def journal_step(
+    step_id: str,
+    status: str,
+    *,
+    detail: Optional[str] = None,
+    error: Optional[str] = None,
+    fsync: bool = False,
+    **extra: Any,
+) -> None:
+    """Record one experiment step transition in the journal."""
+    if status not in VALID_STATUSES:
+        raise ValueError(f"invalid journal status {status!r}; allowed: {sorted(VALID_STATUSES)}")
+
+    writer = get_journal_writer()
+    record: Dict[str, Any] = {
+        "ts": utc_now_iso(),
+        "step_id": step_id,
+        "step_index": next_step_index(),
+        "status": status,
+        "software_version": __version__,
+        **base_fields(),
+    }
+    if detail:
+        record["detail"] = detail
+    if error:
+        record["error"] = error
+    if extra:
+        record["extra"] = extra
+
+    if writer is not None:
+        try:
+            writer.write(record, fsync=fsync or status in ("crashed", "stopped"))
+        except Exception:
+            log.exception("failed to write experiment journal record")
+
+    log.info("journal %s %s%s", step_id, status, f" ({error})" if error else "")

--- a/back/rapidboxes/logging/jsonl.py
+++ b/back/rapidboxes/logging/jsonl.py
@@ -1,0 +1,72 @@
+"""Crash-safe JSON Lines writer with size-based rotation."""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+class JsonlWriter:
+    def __init__(
+        self,
+        path: Path,
+        *,
+        max_bytes: int = 10 * 1024 * 1024,
+        backup_count: int = 5,
+    ):
+        self._path = path
+        self._max_bytes = max_bytes
+        self._backup_count = backup_count
+        self._lock = threading.Lock()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def write(self, record: Dict[str, Any], *, fsync: bool = False) -> None:
+        line = json.dumps(record, default=str, ensure_ascii=False) + "\n"
+        data = line.encode("utf-8")
+        with self._lock:
+            self._rotate_if_needed(len(data))
+            with self._path.open("ab") as f:
+                f.write(data)
+                if fsync:
+                    f.flush()
+                    os.fsync(f.fileno())
+
+    def _rotate_if_needed(self, incoming: int) -> None:
+        if not self._path.exists():
+            return
+        if self._path.stat().st_size + incoming <= self._max_bytes:
+            return
+        for i in range(self._backup_count - 1, 0, -1):
+            src = self._path.with_suffix(self._path.suffix + f".{i}")
+            dst = self._path.with_suffix(self._path.suffix + f".{i + 1}")
+            if src.exists():
+                if dst.exists():
+                    dst.unlink()
+                src.rename(dst)
+        first = self._path.with_suffix(self._path.suffix + ".1")
+        if first.exists():
+            first.unlink()
+        self._path.rename(first)
+
+
+def exception_fields(exc: Optional[BaseException]) -> Optional[Dict[str, Any]]:
+    if exc is None:
+        return None
+    import traceback
+
+    return {
+        "type": type(exc).__name__,
+        "message": str(exc),
+        "traceback": "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+    }

--- a/back/rapidboxes/logging/setup.py
+++ b/back/rapidboxes/logging/setup.py
@@ -1,0 +1,105 @@
+"""Process-wide logging setup: JSONL sinks + stdlib bridge."""
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Optional
+
+from ..config import AppConfig
+from .context import base_fields, new_run_id, set_run_id
+from .error_log import log_error
+from .jsonl import utc_now_iso
+from .system_log import log_system
+from .writers import configure_writers, get_errors_writer
+
+_initialized = False
+
+
+class _JsonlErrorHandler(logging.Handler):
+    """Mirror ERROR+ stdlib records into errors.jsonl with location metadata."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        writer = get_errors_writer()
+        if writer is None:
+            return
+        exc_info = record.exc_info
+        exc: Optional[BaseException] = None
+        if exc_info and exc_info[1] is not None:
+            exc = exc_info[1]
+        fields = base_fields()
+        fields.update(
+            {
+                "ts": utc_now_iso(),
+                "level": record.levelname,
+                "category": record.name,
+                "event": record.funcName or "log",
+                "message": record.getMessage(),
+                "where": {
+                    "module": record.module,
+                    "function": record.funcName,
+                    "line": record.lineno,
+                    "pathname": record.pathname,
+                },
+            }
+        )
+        from .. import __version__
+
+        fields["software_version"] = __version__
+        if exc is not None:
+            from .jsonl import exception_fields
+
+            fields["exception"] = exception_fields(exc)
+        try:
+            writer.write(fields, fsync=record.levelno >= logging.ERROR)
+        except Exception:
+            pass
+
+
+def _excepthook(exc_type, exc, tb) -> None:
+    if _initialized:
+        log_error(
+            "process",
+            "uncaught_exception",
+            str(exc),
+            exc=exc,
+            where={"module": getattr(exc_type, "__module__", ""), "function": "<module>"},
+        )
+    sys.__excepthook__(exc_type, exc, tb)
+
+
+def init_logging(config: AppConfig) -> str:
+    """Configure JSONL writers and stdlib logging. Returns the new run_id."""
+    global _initialized
+
+    configure_writers(config.log_root)
+
+    run_id = new_run_id()
+    set_run_id(run_id)
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.setLevel(logging.INFO)
+
+    stream = logging.StreamHandler(sys.stdout)
+    stream.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    root.addHandler(stream)
+    root.addHandler(_JsonlErrorHandler())
+
+    sys.excepthook = _excepthook
+    _initialized = True
+
+    log_system(
+        "app.startup",
+        "logging initialized",
+        log_root=str(config.log_root),
+        simulation=config.simulation,
+        storage_root=str(config.storage_root),
+    )
+    return run_id
+
+
+def shutdown_logging() -> None:
+    global _initialized
+    if _initialized:
+        log_system("app.shutdown", "logging shutdown")
+    _initialized = False

--- a/back/rapidboxes/logging/system_log.py
+++ b/back/rapidboxes/logging/system_log.py
@@ -1,0 +1,31 @@
+"""Operational system events (system.jsonl)."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from .. import __version__
+from .context import base_fields
+from .jsonl import utc_now_iso
+from .writers import get_system_writer
+
+log = logging.getLogger("rapidboxes.system")
+
+
+def log_system(event: str, message: str, **context: Any) -> None:
+    writer = get_system_writer()
+    record: Dict[str, Any] = {
+        "ts": utc_now_iso(),
+        "event": event,
+        "message": message,
+        "software_version": __version__,
+        **base_fields(),
+    }
+    if context:
+        record["context"] = context
+    if writer is not None:
+        try:
+            writer.write(record)
+        except Exception:
+            log.exception("failed to write system log record")
+    log.info("%s: %s", event, message)

--- a/back/rapidboxes/logging/writers.py
+++ b/back/rapidboxes/logging/writers.py
@@ -1,0 +1,37 @@
+"""Shared JSONL writer instances (set once at startup)."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from .jsonl import JsonlWriter
+
+_log_root: Optional[Path] = None
+_errors: Optional[JsonlWriter] = None
+_journal: Optional[JsonlWriter] = None
+_system: Optional[JsonlWriter] = None
+
+
+def configure_writers(log_root: Path) -> None:
+    global _log_root, _errors, _journal, _system
+    _log_root = log_root
+    log_root.mkdir(parents=True, exist_ok=True)
+    _errors = JsonlWriter(log_root / "errors.jsonl")
+    _journal = JsonlWriter(log_root / "experiment.jsonl")
+    _system = JsonlWriter(log_root / "system.jsonl")
+
+
+def get_log_root() -> Optional[Path]:
+    return _log_root
+
+
+def get_errors_writer() -> Optional[JsonlWriter]:
+    return _errors
+
+
+def get_journal_writer() -> Optional[JsonlWriter]:
+    return _journal
+
+
+def get_system_writer() -> Optional[JsonlWriter]:
+    return _system

--- a/back/rapidboxes/main.py
+++ b/back/rapidboxes/main.py
@@ -10,7 +10,7 @@ import logging
 from contextlib import asynccontextmanager
 from typing import Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -18,29 +18,31 @@ from fastapi.staticfiles import StaticFiles
 from .config import AppConfig, get_config
 from .engine.runner import ExperimentRunner
 from .hardware.manager import build_hardware
+from .logging import init_logging, log_error, shutdown_logging
 from .settings_store import load_device_settings_for_new_session
 from .storage import Storage
 from .api import experiments, health, images, preview, settings as settings_api, system, ws
 from .api.deps import AppState
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 log = logging.getLogger("rapidboxes")
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     config: AppConfig = app.state._config
+    run_id = init_logging(config)
     device_settings = load_device_settings_for_new_session(config.settings_path)
     storage = Storage(config.storage_root)
     hw = build_hardware(config, device_settings)
     runner = ExperimentRunner(hw, storage)
     runner.recover()
     app.state.app = AppState(config, device_settings, storage, hw, runner)
-    log.info("RaPiD-boxes started (simulation=%s, storage=%s)", config.simulation, config.storage_root)
+    log.info("RaPiD-boxes started (run_id=%s, simulation=%s, storage=%s)", run_id, config.simulation, config.storage_root)
     try:
         yield
     finally:
         await runner.shutdown()
+        shutdown_logging()
         log.info("RaPiD-boxes stopped; hardware released")
 
 
@@ -56,6 +58,33 @@ def create_app(config: Optional[AppConfig] = None) -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    @app.middleware("http")
+    async def log_http_errors(request: Request, call_next):
+        try:
+            response = await call_next(request)
+        except Exception as exc:
+            if request.url.path.startswith("/api"):
+                log_error(
+                    "api",
+                    "unhandled_exception",
+                    str(exc),
+                    exc=exc,
+                    path=request.url.path,
+                    method=request.method,
+                )
+            raise
+        if response.status_code >= 500 and request.url.path.startswith("/api"):
+            log_error(
+                "api",
+                "http_error",
+                f"HTTP {response.status_code}",
+                level="ERROR",
+                path=request.url.path,
+                method=request.method,
+                status_code=response.status_code,
+            )
+        return response
 
     for module in (experiments, images, settings_api, system, preview, health):
         app.include_router(module.router)

--- a/back/rapidboxes/settings_store.py
+++ b/back/rapidboxes/settings_store.py
@@ -5,6 +5,7 @@ import logging
 import os
 from pathlib import Path
 
+from .logging import log_error
 from .models import CameraSettings, DeviceSettings
 
 log = logging.getLogger("rapidboxes.settings")
@@ -14,8 +15,9 @@ def load_device_settings(path: Path) -> DeviceSettings:
     if path.exists():
         try:
             return DeviceSettings.model_validate_json(path.read_text())
-        except Exception:
+        except Exception as exc:
             log.exception("invalid settings file %s; using defaults", path)
+            log_error("settings", "invalid_settings_file", str(exc), exc=exc, path=str(path))
     return DeviceSettings()
 
 

--- a/back/tests/test_engine.py
+++ b/back/tests/test_engine.py
@@ -4,11 +4,13 @@ Drives a full two-phase experiment in milliseconds by injecting a fake time
 source + sleep, so we can assert capture counts, file output, and cleanup.
 """
 import asyncio
+import json
 from pathlib import Path
 
 import pytest
 
 from rapidboxes.config import AppConfig
+from rapidboxes.logging import init_logging, shutdown_logging
 from rapidboxes.engine.runner import ExperimentRunner
 from rapidboxes.hardware.base import BLACK, white
 from rapidboxes.hardware.manager import build_hardware
@@ -34,13 +36,16 @@ class FakeTime:
         await asyncio.sleep(0)  # yield so listeners/captures run
 
 
-def _runner(tmp_path: Path, ft: FakeTime) -> ExperimentRunner:
+def _runner(tmp_path: Path, ft: FakeTime, *, with_logging: bool = False) -> ExperimentRunner:
     config = AppConfig(
         simulation=True,
         storage_root=tmp_path / "exp",
         settings_path=tmp_path / "settings.json",
+        log_root=tmp_path / "logs",
     )
     config.ensure_dirs()
+    if with_logging:
+        init_logging(config)
     hw = build_hardware(config, DeviceSettings())
     storage = Storage(config.storage_root)
     return ExperimentRunner(hw, storage, now=ft.now, sleep=ft.sleep, tick_seconds=10_000)
@@ -164,3 +169,30 @@ async def test_growth_protocol_baseline_day_night_rgbw_flash(tmp_path):
     # Hardware left safe: all LEDs black, IR off.
     assert runner._hw._ir.state is False
     assert all(p == BLACK for p in runner._hw._leds.pixels)
+
+
+@pytest.mark.asyncio
+async def test_experiment_journal_records_steps(tmp_path):
+    ft = FakeTime()
+    runner = _runner(tmp_path, ft, with_logging=True)
+    config = TropismConfig(
+        experimentName="t",
+        username="u",
+        darkPhaseEnabled=True,
+        darkPhaseHours=60 / 3600,
+        lateralIlluminationHours=0,
+        intervalMinutes=1.0,
+    )
+    await runner.start(config)
+    await runner._task
+    shutdown_logging()
+
+    journal_path = tmp_path / "logs" / "experiment.jsonl"
+    lines = [json.loads(line) for line in journal_path.read_text().splitlines()]
+    step_ids = [r["step_id"] for r in lines]
+    assert "experiment.start" in step_ids
+    assert "experiment.configure_camera" in step_ids
+    assert "experiment.finalize" in step_ids
+    finalize = [r for r in lines if r["step_id"] == "experiment.finalize"][-1]
+    assert finalize["status"] == "done"
+    assert any(r["step_id"].startswith("phase.dark.capture.") for r in lines)

--- a/back/tests/test_logging.py
+++ b/back/tests/test_logging.py
@@ -1,0 +1,89 @@
+"""Tests for structured JSONL logging."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from rapidboxes.config import AppConfig
+from rapidboxes.logging import init_logging, journal_step, log_error, log_system, shutdown_logging
+from rapidboxes.logging.context import get_run_id, set_experiment_context
+from rapidboxes.logging.jsonl import JsonlWriter
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_jsonl_writer_rotation(tmp_path: Path):
+    writer = JsonlWriter(tmp_path / "test.jsonl", max_bytes=200, backup_count=2)
+    for i in range(30):
+        writer.write({"n": i, "payload": "x" * 20})
+    assert (tmp_path / "test.jsonl").exists()
+    assert (tmp_path / "test.jsonl.1").exists()
+
+
+def test_init_logging_creates_files(tmp_path: Path):
+    cfg = AppConfig(
+        simulation=True,
+        storage_root=tmp_path / "exp",
+        settings_path=tmp_path / "settings.json",
+        log_root=tmp_path / "logs",
+    )
+    cfg.ensure_dirs()
+    run_id = init_logging(cfg)
+    assert run_id
+    assert get_run_id() == run_id
+
+    log_error("test", "sample_error", "something broke", detail="x")
+    journal_step("experiment.start", "started", detail="protocol=tropism")
+    set_experiment_context("exp-1", protocol="tropism")
+    journal_step("phase.dark", "done")
+    log_system("test.event", "hello")
+
+    shutdown_logging()
+
+    errors = _read_jsonl(tmp_path / "logs" / "errors.jsonl")
+    journal = _read_jsonl(tmp_path / "logs" / "experiment.jsonl")
+    system = _read_jsonl(tmp_path / "logs" / "system.jsonl")
+
+    assert any(r["event"] == "sample_error" for r in errors)
+    assert errors[0]["software_version"]
+    assert errors[0]["where"]["function"]
+
+    assert journal[0]["step_id"] == "experiment.start"
+    assert journal[0]["status"] == "started"
+    assert journal[-1]["experiment_id"] == "exp-1"
+
+    assert any(r["event"] == "app.startup" for r in system)
+    assert any(r["event"] == "app.shutdown" for r in system)
+
+
+def test_stdlib_errors_mirrored_to_jsonl(tmp_path: Path, caplog):
+    cfg = AppConfig(
+        simulation=True,
+        storage_root=tmp_path / "exp",
+        settings_path=tmp_path / "settings.json",
+        log_root=tmp_path / "logs",
+    )
+    init_logging(cfg)
+    log = logging.getLogger("rapidboxes.test")
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError:
+        log.exception("caught failure")
+    shutdown_logging()
+
+    errors = _read_jsonl(tmp_path / "logs" / "errors.jsonl")
+    mirrored = [r for r in errors if r.get("message") == "caught failure"]
+    assert mirrored
+    assert mirrored[0]["exception"]["type"] == "RuntimeError"
+
+
+def test_journal_rejects_invalid_status():
+    with pytest.raises(ValueError):
+        journal_step("step", "invalid")

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -66,7 +66,10 @@ RAPIDBOXES_PORT=$PORT
 RAPIDBOXES_SPA_DIR=$FRONT_DIR/dist/spa
 RAPIDBOXES_STORAGE_ROOT=$HOME_DIR/rapidboxes/experiments
 RAPIDBOXES_SETTINGS_PATH=$HOME_DIR/rapidboxes/settings.json
+RAPIDBOXES_LOG_ROOT=$HOME_DIR/rapidboxes/logs
 EOF
+
+mkdir -p "$HOME_DIR/rapidboxes/logs"
 
 echo "==> Installing systemd service..."
 sed -e "s|@USER@|$RUN_USER|g" \
@@ -88,6 +91,8 @@ cat <<EOF
 ==> Done.
     Backend:  systemctl status rapidboxes      (http://localhost:$PORT)
     Logs:     journalctl -u rapidboxes -f
+              tail -f $HOME_DIR/rapidboxes/logs/errors.jsonl
+              tail -f $HOME_DIR/rapidboxes/logs/experiment.jsonl
     Reboot to apply SPI/camera/group changes and launch the kiosk:
         sudo reboot
 EOF


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Phase 1 of the logging pipeline: structured JSONL logs on every RaPiD-box device with timestamped error records and a step-by-step experiment journal.

## What's included

### New `rapidboxes.logging` package
- **`errors.jsonl`** — structured errors with UTC timestamps, category/event, caller location, exception tracebacks, `run_id`, and software version
- **`experiment.jsonl`** — experiment step journal (`started` / `done` / `stopped` / `crashed` / `skipped`) with `step_id`, `step_index`, and correlation fields
- **`system.jsonl`** — operational events (startup, shutdown, hardware mode)
- Stdlib logging bridge mirrors `ERROR+` records into `errors.jsonl`
- Uncaught exception hook writes to the error log before exit

### Instrumentation
- **`ExperimentRunner`**: journal entries for start, XML write, camera configure, each phase, each capture, cleanup, and finalize
- **`HardwareManager`**: explicit errors on shutdown/camera-unavailable; system events for sim vs real mode
- **`settings_store`**: errors on corrupt settings JSON
- **`main.py`**: HTTP middleware logs API 5xx and unhandled exceptions
- Config: `RAPIDBOXES_LOG_ROOT` (default `~/rapidboxes/logs`)

### Deploy
- `deploy/install.sh` creates log directory and sets `RAPIDBOXES_LOG_ROOT`

## Log locations on Pi

```
~/rapidboxes/logs/errors.jsonl
~/rapidboxes/logs/experiment.jsonl
~/rapidboxes/logs/system.jsonl
```

## Tests

- `test_logging.py` — JSONL rotation, init/shutdown, stdlib bridge, journal validation
- `test_engine.py` — full tropism run produces expected journal steps

All 27 backend tests pass.

## Next steps (not in this PR)

- Local triage service + email outbound
- Machine identity (`device.json`) and git commit stamping at install
- Frontend client error shipping
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1d16-9771-7cd8-a6df-4ff1065a2299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1d16-9771-7cd8-a6df-4ff1065a2299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

