### PR TITLE
Add OTA self-update: manual button + monthly timer

### DIFF
--- a/back/rapidboxes/api/update.py
+++ b/back/rapidboxes/api/update.py
@@ -13,7 +13,7 @@ import asyncio
 from fastapi import APIRouter, Depends
 
 from ..models import UpdateApplyResult, UpdateCheckResult
-from ..updater import apply_update, check_for_update
+from ..updater import BUSY_EXPERIMENT_STATES, apply_update, check_for_update
 from .deps import AppState, get_state
 
 router = APIRouter(prefix="/api/system/update", tags=["update"])
@@ -21,7 +21,10 @@ router = APIRouter(prefix="/api/system/update", tags=["update"])
 
 @router.get("/check", response_model=UpdateCheckResult)
 async def check(state: AppState = Depends(get_state)):
-    """git fetch + compare HEAD to origin/<update_branch>. Read-only."""
+    """git fetch + compare HEAD to origin/<update_branch>. Read-only.
+
+    Always allowed, even mid-experiment -- it never touches the working tree.
+    """
     # git fetch does network I/O; run off the event loop so it can't stall
     # the WS status feed / MJPEG preview during an active experiment.
     return await asyncio.to_thread(check_for_update, state.config.update_branch)
@@ -29,5 +32,17 @@ async def check(state: AppState = Depends(get_state)):
 
 @router.post("/apply", response_model=UpdateApplyResult)
 async def apply(state: AppState = Depends(get_state)):
-    """git fetch + `merge --ff-only`. Refuses (no-op) if it can't fast-forward."""
+    """git fetch + `merge --ff-only`. Refuses (no-op) if it can't fast-forward.
+
+    Also refuses outright while an experiment is running/paused/finishing --
+    this process is in-process with the live ExperimentRunner (unlike the
+    CLI/timer path, which has to ask over loopback HTTP; see
+    updater.check_experiment_active_via_http), so we can just read
+    state.runner.status.state directly.
+    """
+    if state.runner.status.state in BUSY_EXPERIMENT_STATES:
+        return UpdateApplyResult(
+            status="experiment_active",
+            message="Finish or stop the current experiment before updating.",
+        )
     return await asyncio.to_thread(apply_update, state.config.update_branch)

--- a/back/rapidboxes/api/update.py
+++ b/back/rapidboxes/api/update.py
@@ -1,0 +1,33 @@
+"""OTA self-update endpoints for the Settings -> General "Update" button.
+
+Both endpoints only ever fetch + fast-forward-merge (see ../updater.py); they
+never reset or discard local changes. Applying an update does not restart the
+service itself -- the frontend shows a "restart now?" dialog after a
+successful apply and, on confirm, calls the existing POST
+/api/system/restart-service endpoint (see api/system.py).
+"""
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import APIRouter, Depends
+
+from ..models import UpdateApplyResult, UpdateCheckResult
+from ..updater import apply_update, check_for_update
+from .deps import AppState, get_state
+
+router = APIRouter(prefix="/api/system/update", tags=["update"])
+
+
+@router.get("/check", response_model=UpdateCheckResult)
+async def check(state: AppState = Depends(get_state)):
+    """git fetch + compare HEAD to origin/<update_branch>. Read-only."""
+    # git fetch does network I/O; run off the event loop so it can't stall
+    # the WS status feed / MJPEG preview during an active experiment.
+    return await asyncio.to_thread(check_for_update, state.config.update_branch)
+
+
+@router.post("/apply", response_model=UpdateApplyResult)
+async def apply(state: AppState = Depends(get_state)):
+    """git fetch + `merge --ff-only`. Refuses (no-op) if it can't fast-forward."""
+    return await asyncio.to_thread(apply_update, state.config.update_branch)

--- a/back/rapidboxes/config.py
+++ b/back/rapidboxes/config.py
@@ -56,6 +56,17 @@ class AppConfig(BaseSettings):
     # Live preview (MJPEG) target frame rate.
     preview_fps: float = 5.0
 
+    # Branch this device tracks for the OTA self-update feature (Settings ->
+    # General -> Update button, and the monthly rapidboxes-update.timer).
+    # Judgment call: defaults to "main" as the intended long-term stable
+    # branch, but whatever branch is actually checked out on a given device
+    # may differ (e.g. this repo is developed on "v2" while "main" is the
+    # older/stable branch) -- override with RAPIDBOXES_UPDATE_BRANCH so
+    # `git fetch origin <branch>` / `git merge --ff-only origin/<branch>`
+    # compares against the branch this deployment is meant to track, not
+    # blindly against origin/main.
+    update_branch: str = "main"
+
     def ensure_dirs(self) -> None:
         self.storage_root.mkdir(parents=True, exist_ok=True)
         self.settings_path.parent.mkdir(parents=True, exist_ok=True)

--- a/back/rapidboxes/main.py
+++ b/back/rapidboxes/main.py
@@ -20,7 +20,7 @@ from .engine.runner import ExperimentRunner
 from .hardware.manager import build_hardware
 from .settings_store import load_device_settings_for_new_session
 from .storage import Storage
-from .api import experiments, health, images, preview, settings as settings_api, system, ws
+from .api import experiments, health, images, preview, settings as settings_api, system, update, ws
 from .api.deps import AppState
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
@@ -57,7 +57,7 @@ def create_app(config: Optional[AppConfig] = None) -> FastAPI:
         allow_headers=["*"],
     )
 
-    for module in (experiments, images, settings_api, system, preview, health):
+    for module in (experiments, images, settings_api, system, update, preview, health):
         app.include_router(module.router)
     app.include_router(ws.router)
 

--- a/back/rapidboxes/models.py
+++ b/back/rapidboxes/models.py
@@ -305,6 +305,30 @@ class SystemInfo(BaseModel):
     cameraAvailable: bool = True
 
 
+# ---------------------------------------------------------------------------
+# OTA self-update (Settings -> General -> Update button, and the monthly
+# rapidboxes-update.timer). See rapidboxes/updater.py for the git plumbing.
+# ---------------------------------------------------------------------------
+
+
+class UpdateCheckResult(BaseModel):
+    branch: str
+    updateAvailable: bool
+    currentCommit: Optional[str] = None
+    remoteCommit: Optional[str] = None
+    commitsBehind: int = 0
+    # Short "<hash> <subject>" lines, newest first, capped (see updater.py).
+    commitLog: List[str] = []
+    error: Optional[str] = None
+
+
+class UpdateApplyResult(BaseModel):
+    status: str  # "updated" | "up_to_date" | "error"
+    message: str
+    fromCommit: Optional[str] = None
+    toCommit: Optional[str] = None
+
+
 class StartResponse(BaseModel):
     status: str  # "started" | "busy" | "no_camera"
     experimentId: Optional[str] = None

--- a/back/rapidboxes/models.py
+++ b/back/rapidboxes/models.py
@@ -323,10 +323,17 @@ class UpdateCheckResult(BaseModel):
 
 
 class UpdateApplyResult(BaseModel):
-    status: str  # "updated" | "up_to_date" | "error"
+    status: str  # "updated" | "up_to_date" | "error" | "experiment_active"
     message: str
     fromCommit: Optional[str] = None
     toCommit: Optional[str] = None
+    # Set only when status == "updated": whether the post-pull dependency /
+    # frontend-build step ran, and how it went. "failed" means the git pull
+    # succeeded but the running process is now on mismatched code/deps -- a
+    # worse state than a clean refusal, so callers must NOT treat this as a
+    # green light to restart (see updater.py).
+    rebuildStatus: Optional[str] = None  # None | "skipped" | "ok" | "failed"
+    rebuildMessage: Optional[str] = None
 
 
 class StartResponse(BaseModel):

--- a/back/rapidboxes/updater.py
+++ b/back/rapidboxes/updater.py
@@ -6,41 +6,57 @@ Backs both the manual "Update" button (Settings -> General, via
 CLI: `python -m rapidboxes.updater apply --restart-on-success`).
 
 Safety:
-- Every git invocation is a fixed argument list passed to `subprocess.run`
-  (never `shell=True` / string interpolation), so there is no command
-  injection surface even though the branch name is config-controlled.
+- Every git/pip/npm invocation is a fixed argument list passed to
+  `subprocess.run` (never `shell=True` / string interpolation), so there is
+  no command injection surface even though the branch name is
+  config-controlled.
 - Only `git fetch` and `git merge --ff-only` are used to apply an update.
   A fast-forward is a strictly additive move of the local branch pointer; if
   the working tree is dirty or history has diverged, the merge is refused by
   git itself and we surface that as an error instead of falling back to
   anything destructive like `reset --hard`.
+- An update is refused outright (no fetch/merge attempted) while an
+  experiment is running/paused/finishing -- see `BUSY_EXPERIMENT_STATES`,
+  the in-process check in `api/update.py`, and `check_experiment_active_via_http`
+  for the CLI's out-of-process equivalent.
 """
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
-from .models import UpdateApplyResult, UpdateCheckResult
+from .models import ExperimentState, UpdateApplyResult, UpdateCheckResult
+
+# Experiment states that make an update unsafe to apply -- mirrors the
+# "busy" check in engine/runner.py's own start() guard.
+BUSY_EXPERIMENT_STATES = frozenset(
+    {ExperimentState.running.value, ExperimentState.paused.value, ExperimentState.finishing.value}
+)
 
 # Cap on how many "<hash> <subject>" lines we return from a check -- enough to
 # skim, not a changelog dump.
 _MAX_LOG_LINES = 10
 
 _GIT_TIMEOUT_S = 30
+# pip/npm can be slow, especially on a Pi -- generous but bounded so a hung
+# network call can't wedge the monthly timer (or a request thread) forever.
+_PIP_TIMEOUT_S = 600
+_NPM_TIMEOUT_S = 600
 
 _repo_root_cache: Optional[Path] = None
 
 
 class UpdaterError(RuntimeError):
-    """A git command failed, timed out, or git itself is unavailable."""
+    """A git/pip/npm command failed, timed out, or the executable is missing."""
 
 
-def _run_git(args: List[str], cwd: Path, timeout: int = _GIT_TIMEOUT_S) -> str:
-    """Run `git <args>` as a fixed argument list (no shell) and return stdout."""
+def _run_cmd(args: List[str], cwd: Path, timeout: int) -> str:
+    """Run a fixed argument list (no shell) and return stdout, or raise."""
     try:
         result = subprocess.run(
-            ["git", *args],
+            args,
             cwd=str(cwd),
             capture_output=True,
             text=True,
@@ -48,14 +64,19 @@ def _run_git(args: List[str], cwd: Path, timeout: int = _GIT_TIMEOUT_S) -> str:
             check=False,
         )
     except FileNotFoundError as e:
-        raise UpdaterError("git executable not found") from e
+        raise UpdaterError(f"{args[0]} not found") from e
     except subprocess.TimeoutExpired as e:
-        raise UpdaterError(f"git {' '.join(args)} timed out after {timeout}s") from e
+        raise UpdaterError(f"{' '.join(args)} timed out after {timeout}s") from e
 
     if result.returncode != 0:
         detail = (result.stderr or result.stdout or "").strip()
-        raise UpdaterError(detail or f"git {' '.join(args)} failed (exit {result.returncode})")
+        raise UpdaterError(detail or f"{' '.join(args)} failed (exit {result.returncode})")
     return result.stdout
+
+
+def _run_git(args: List[str], cwd: Path, timeout: int = _GIT_TIMEOUT_S) -> str:
+    """Run `git <args>` as a fixed argument list (no shell) and return stdout."""
+    return _run_cmd(["git", *args], cwd, timeout)
 
 
 def get_repo_root() -> Path:
@@ -67,6 +88,101 @@ def get_repo_root() -> Path:
     root = _run_git(["rev-parse", "--show-toplevel"], here).strip()
     _repo_root_cache = Path(root)
     return _repo_root_cache
+
+
+# ---------------------------------------------------------------------------
+# Post-pull rebuild: mirrors deploy/update.sh's "pip install ... && npm
+# install && npm run build" exactly, so there is one source of truth for how
+# this project is rebuilt after new code lands, whether that's a human
+# running update.sh by hand or the OTA path pulling automatically. Only the
+# half (backend/frontend) that actually changed is rebuilt.
+# ---------------------------------------------------------------------------
+
+
+def _changed_paths(before: str, after: str, repo: Path) -> List[str]:
+    out = _run_git(["diff", "--name-only", f"{before}..{after}"], repo)
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def _needs_backend_rebuild(paths: List[str]) -> bool:
+    # deploy/install.sh and deploy/update.sh install the backend as a normal
+    # (non-editable) package -- `pip install "$BACK_DIR[pi]"` -- so a running
+    # process is on a *copy* of back/rapidboxes in site-packages. Any change
+    # under back/ (not just pyproject.toml) needs a reinstall to take effect.
+    return any(p == "back" or p.startswith("back/") for p in paths)
+
+
+def _needs_frontend_rebuild(paths: List[str]) -> bool:
+    return any(p == "front" or p.startswith("front/") for p in paths)
+
+
+def _venv_pip() -> Path:
+    """pip alongside the interpreter currently running this process.
+
+    systemd's ExecStart (both rapidboxes.service and rapidboxes-update.service)
+    points at `@VENV@/bin/python`, so `sys.executable` *is* the venv this app
+    was installed into -- more robust than assuming a fixed `back/.venv` path.
+    """
+    return Path(sys.executable).resolve().parent / "pip"
+
+
+def _find_front_dir(repo: Path) -> Optional[Path]:
+    """Mirror deploy/update.sh's `find front -maxdepth 3 -name package.json`."""
+    front_root = repo / "front"
+    if not front_root.is_dir():
+        return None
+    matches = sorted(front_root.glob("package.json"))
+    matches += sorted(front_root.glob("*/package.json"))
+    matches += sorted(front_root.glob("*/*/package.json"))
+    return matches[0].parent if matches else None
+
+
+def _rebuild_backend(repo: Path) -> None:
+    back_dir = repo / "back"
+    pip = _venv_pip()
+    # Same as deploy/update.sh: `pip install "$BACK_DIR[pi]"` (the Pi hardware
+    # extras), not "[dev]" -- this is the production deploy path.
+    _run_cmd([str(pip), "install", f"{back_dir}[pi]"], repo, timeout=_PIP_TIMEOUT_S)
+
+
+def _rebuild_frontend(repo: Path) -> None:
+    front_dir = _find_front_dir(repo)
+    if front_dir is None:
+        raise UpdaterError("could not locate the front-end project (no package.json under front/)")
+    # Same as deploy/update.sh.
+    _run_cmd(["npm", "install", "--no-audit", "--no-fund"], front_dir, timeout=_NPM_TIMEOUT_S)
+    _run_cmd(["npm", "run", "build"], front_dir, timeout=_NPM_TIMEOUT_S)
+
+
+def _rebuild_after_pull(before: str, after: str, repo: Path) -> Tuple[str, str]:
+    """Returns (rebuildStatus, rebuildMessage) for UpdateApplyResult.
+
+    Best-effort change detection: if `git diff --name-only` itself fails for
+    some reason, fail safe by rebuilding both rather than silently skipping.
+    """
+    try:
+        changed = _changed_paths(before, after, repo)
+        needs_backend = _needs_backend_rebuild(changed)
+        needs_frontend = _needs_frontend_rebuild(changed)
+    except UpdaterError:
+        changed = []
+        needs_backend = True
+        needs_frontend = True
+
+    if not needs_backend and not needs_frontend:
+        return "skipped", "No backend or frontend changes; nothing to rebuild."
+
+    done: List[str] = []
+    try:
+        if needs_backend:
+            _rebuild_backend(repo)
+            done.append("backend deps")
+        if needs_frontend:
+            _rebuild_frontend(repo)
+            done.append("frontend build")
+        return "ok", f"Rebuilt: {', '.join(done)}."
+    except UpdaterError as e:
+        return "failed", f"Pulled new code but rebuild failed after {', '.join(done) or 'nothing'}: {e}"
 
 
 def check_for_update(branch: str, repo_root: Optional[Path] = None) -> UpdateCheckResult:
@@ -122,6 +238,17 @@ def apply_update(branch: str, repo_root: Optional[Path] = None) -> UpdateApplyRe
     impossible -- fixing that is a human/manual-deploy decision, never an
     automatic `reset --hard`.
 
+    On a successful fast-forward, rebuilds whichever half (backend deps /
+    frontend build) actually changed -- see `_rebuild_after_pull` -- and
+    reports that separately via rebuildStatus/rebuildMessage, since a pull
+    that succeeded but whose rebuild failed leaves the process on mismatched
+    code and deps, a worse state than a clean refusal.
+
+    Does NOT check whether an experiment is active -- callers (the API
+    endpoint / the CLI's `main()`) must gate on that themselves first, since
+    only they know how to observe live state (in-process vs. over loopback
+    HTTP). See `check_experiment_active_via_http` for the CLI's version.
+
     `repo_root` defaults to the real repo (autodetected via `git rev-parse
     --show-toplevel`); tests pass a throwaway repo instead.
     """
@@ -160,11 +287,15 @@ def apply_update(branch: str, repo_root: Optional[Path] = None) -> UpdateApplyRe
                 toCommit=after[:8],
             )
 
+        rebuild_status, rebuild_message = _rebuild_after_pull(before, after, repo)
+
         return UpdateApplyResult(
             status="updated",
             message=f"Updated {before[:8]} -> {after[:8]}.",
             fromCommit=before[:8],
             toCommit=after[:8],
+            rebuildStatus=rebuild_status,
+            rebuildMessage=rebuild_message,
         )
     except UpdaterError as e:
         return UpdateApplyResult(status="error", message=str(e))
@@ -193,6 +324,32 @@ def _trigger_restart(port: int) -> None:
         pass
 
 
+def check_experiment_active_via_http(port: int, timeout: float = 5.0) -> bool:
+    """Best-effort loopback check of whether an experiment is running.
+
+    The CLI (invoked by the systemd timer) is a *separate process* from the
+    running rapidboxes.service and has no direct access to the live
+    ExperimentRunner, so it asks the already-running server the same way the
+    kiosk UI does: GET /api/experiments/current (see api/experiments.py),
+    which returns the same ExperimentStatus.state the in-process API check
+    uses (api/update.py).
+
+    Any failure to reach it (server down, timeout, bad response) is treated
+    as "active" -- refuse to update -- since skipping one monthly update is
+    far cheaper than guessing wrong and interrupting a multi-day protocol.
+    """
+    import json
+    import urllib.request
+
+    req = urllib.request.Request(f"http://127.0.0.1:{port}/api/experiments/current")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = json.loads(resp.read().decode())
+        return body.get("state") in BUSY_EXPERIMENT_STATES
+    except Exception:
+        return True
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     import argparse
     import sys
@@ -206,8 +363,9 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument(
         "--restart-on-success",
         action="store_true",
-        help="After a successful 'apply' that pulled new commits, POST "
-        "/api/system/restart-service to the locally running instance.",
+        help="After a successful 'apply' that pulled new commits (and whose "
+        "rebuild, if any, succeeded), POST /api/system/restart-service to "
+        "the locally running instance.",
     )
     args = parser.parse_args(argv)
 
@@ -218,10 +376,32 @@ def main(argv: Optional[List[str]] = None) -> int:
         print(result.model_dump_json())
         return 1 if result.error else 0
 
+    # apply: refuse outright if an experiment looks active -- same "clean
+    # refusal, no partial state" pattern as the dirty-tree / diverged-history
+    # cases inside apply_update() itself. Persistent=true on the timer (plus
+    # next month's run) covers the case where this is skipped.
+    if check_experiment_active_via_http(config.port):
+        result = UpdateApplyResult(
+            status="experiment_active",
+            message="An experiment appears to be active (or its status could not "
+            "be verified); refusing to update.",
+        )
+        print(result.model_dump_json())
+        print(result.message, file=sys.stderr)
+        return 1
+
     result = apply_update(config.update_branch)
     print(result.model_dump_json())
 
     if result.status == "updated" and args.restart_on_success:
+        if result.rebuildStatus == "failed":
+            print(
+                f"warning: pull succeeded but rebuild failed ({result.rebuildMessage}); "
+                "NOT restarting -- code and installed deps are now mismatched, needs "
+                "manual attention (e.g. deploy/update.sh).",
+                file=sys.stderr,
+            )
+            return 2
         try:
             _trigger_restart(config.port)
         except Exception as e:  # noqa: BLE001 - report and exit non-zero, don't crash the timer

--- a/back/rapidboxes/updater.py
+++ b/back/rapidboxes/updater.py
@@ -1,0 +1,235 @@
+"""OTA self-update: git-only, fast-forward-only, no destructive resets.
+
+Backs both the manual "Update" button (Settings -> General, via
+`api/update.py`) and the unattended monthly check (`deploy/rapidboxes-update
+.timer` -> `deploy/rapidboxes-update.service`, which runs this module as a
+CLI: `python -m rapidboxes.updater apply --restart-on-success`).
+
+Safety:
+- Every git invocation is a fixed argument list passed to `subprocess.run`
+  (never `shell=True` / string interpolation), so there is no command
+  injection surface even though the branch name is config-controlled.
+- Only `git fetch` and `git merge --ff-only` are used to apply an update.
+  A fast-forward is a strictly additive move of the local branch pointer; if
+  the working tree is dirty or history has diverged, the merge is refused by
+  git itself and we surface that as an error instead of falling back to
+  anything destructive like `reset --hard`.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import List, Optional
+
+from .models import UpdateApplyResult, UpdateCheckResult
+
+# Cap on how many "<hash> <subject>" lines we return from a check -- enough to
+# skim, not a changelog dump.
+_MAX_LOG_LINES = 10
+
+_GIT_TIMEOUT_S = 30
+
+_repo_root_cache: Optional[Path] = None
+
+
+class UpdaterError(RuntimeError):
+    """A git command failed, timed out, or git itself is unavailable."""
+
+
+def _run_git(args: List[str], cwd: Path, timeout: int = _GIT_TIMEOUT_S) -> str:
+    """Run `git <args>` as a fixed argument list (no shell) and return stdout."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as e:
+        raise UpdaterError("git executable not found") from e
+    except subprocess.TimeoutExpired as e:
+        raise UpdaterError(f"git {' '.join(args)} timed out after {timeout}s") from e
+
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise UpdaterError(detail or f"git {' '.join(args)} failed (exit {result.returncode})")
+    return result.stdout
+
+
+def get_repo_root() -> Path:
+    """Resolve the git repo root once (this file lives at <repo>/back/rapidboxes/)."""
+    global _repo_root_cache
+    if _repo_root_cache is not None:
+        return _repo_root_cache
+    here = Path(__file__).resolve().parent
+    root = _run_git(["rev-parse", "--show-toplevel"], here).strip()
+    _repo_root_cache = Path(root)
+    return _repo_root_cache
+
+
+def check_for_update(branch: str, repo_root: Optional[Path] = None) -> UpdateCheckResult:
+    """`git fetch origin <branch>`, then compare local HEAD to origin/<branch>.
+
+    Never mutates the working tree -- fetch only updates the local view of
+    the remote (refs/remotes/origin/<branch>), not any checked-out files.
+
+    `repo_root` defaults to the real repo (autodetected via `git rev-parse
+    --show-toplevel`); tests pass a throwaway repo instead.
+    """
+    try:
+        repo = repo_root or get_repo_root()
+        _run_git(["fetch", "origin", branch], repo)
+        local = _run_git(["rev-parse", "HEAD"], repo).strip()
+        remote = _run_git(["rev-parse", f"origin/{branch}"], repo).strip()
+
+        if local == remote:
+            return UpdateCheckResult(
+                branch=branch,
+                updateAvailable=False,
+                currentCommit=local[:8],
+                remoteCommit=remote[:8],
+                commitsBehind=0,
+                commitLog=[],
+            )
+
+        behind_raw = _run_git(["rev-list", "--count", f"HEAD..origin/{branch}"], repo).strip()
+        behind = int(behind_raw) if behind_raw.isdigit() else 0
+
+        log_raw = _run_git(
+            ["log", "--oneline", f"-n{_MAX_LOG_LINES}", f"HEAD..origin/{branch}"], repo
+        )
+        log_lines = [line for line in log_raw.splitlines() if line.strip()]
+
+        return UpdateCheckResult(
+            branch=branch,
+            updateAvailable=behind > 0,
+            currentCommit=local[:8],
+            remoteCommit=remote[:8],
+            commitsBehind=behind,
+            commitLog=log_lines,
+        )
+    except UpdaterError as e:
+        return UpdateCheckResult(branch=branch, updateAvailable=False, error=str(e))
+
+
+def apply_update(branch: str, repo_root: Optional[Path] = None) -> UpdateApplyResult:
+    """`git fetch origin <branch>` then `git merge --ff-only origin/<branch>`.
+
+    Refuses (returns status="error", changes nothing) if the working tree has
+    local modifications or history has diverged such that a fast-forward is
+    impossible -- fixing that is a human/manual-deploy decision, never an
+    automatic `reset --hard`.
+
+    `repo_root` defaults to the real repo (autodetected via `git rev-parse
+    --show-toplevel`); tests pass a throwaway repo instead.
+    """
+    try:
+        repo = repo_root or get_repo_root()
+        _run_git(["fetch", "origin", branch], repo)
+
+        dirty = _run_git(["status", "--porcelain"], repo).strip()
+        if dirty:
+            return UpdateApplyResult(
+                status="error",
+                message=(
+                    "Working tree has local changes; refusing to update. "
+                    "Resolve manually (e.g. via deploy/update.sh) before retrying."
+                ),
+            )
+
+        before = _run_git(["rev-parse", "HEAD"], repo).strip()
+
+        try:
+            _run_git(["merge", "--ff-only", f"origin/{branch}"], repo)
+        except UpdaterError as e:
+            return UpdateApplyResult(
+                status="error",
+                message=f"Fast-forward failed (local history has diverged): {e}",
+                fromCommit=before[:8],
+            )
+
+        after = _run_git(["rev-parse", "HEAD"], repo).strip()
+
+        if before == after:
+            return UpdateApplyResult(
+                status="up_to_date",
+                message="Already up to date.",
+                fromCommit=before[:8],
+                toCommit=after[:8],
+            )
+
+        return UpdateApplyResult(
+            status="updated",
+            message=f"Updated {before[:8]} -> {after[:8]}.",
+            fromCommit=before[:8],
+            toCommit=after[:8],
+        )
+    except UpdaterError as e:
+        return UpdateApplyResult(status="error", message=str(e))
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point for the unattended monthly update
+# (deploy/rapidboxes-update.service runs:
+#   python -m rapidboxes.updater apply --restart-on-success).
+# No user is present to click "Restart", so on a successful pull we ask the
+# already-running service to restart itself over loopback HTTP -- the exact
+# same POST /api/system/restart-service path the manual "Update" button (and
+# the kiosk's own restart-after-settings-change flow) uses. That endpoint just
+# SIGKILLs its own pid and relies on systemd's Restart=always, so this script
+# needs no sudo/systemctl access of its own.
+# ---------------------------------------------------------------------------
+
+
+def _trigger_restart(port: int) -> None:
+    import urllib.request
+
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/api/system/restart-service", method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=5):
+        pass
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    import argparse
+    import sys
+
+    from .config import get_config
+
+    parser = argparse.ArgumentParser(
+        description="RaPiD-boxes OTA updater (git fetch + fast-forward-only pull)."
+    )
+    parser.add_argument("action", choices=["check", "apply"])
+    parser.add_argument(
+        "--restart-on-success",
+        action="store_true",
+        help="After a successful 'apply' that pulled new commits, POST "
+        "/api/system/restart-service to the locally running instance.",
+    )
+    args = parser.parse_args(argv)
+
+    config = get_config()
+
+    if args.action == "check":
+        result = check_for_update(config.update_branch)
+        print(result.model_dump_json())
+        return 1 if result.error else 0
+
+    result = apply_update(config.update_branch)
+    print(result.model_dump_json())
+
+    if result.status == "updated" and args.restart_on_success:
+        try:
+            _trigger_restart(config.port)
+        except Exception as e:  # noqa: BLE001 - report and exit non-zero, don't crash the timer
+            print(f"warning: pull succeeded but restart trigger failed: {e}", file=sys.stderr)
+            return 2
+
+    return 1 if result.status == "error" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/back/tests/test_api.py
+++ b/back/tests/test_api.py
@@ -8,7 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from rapidboxes.config import AppConfig
 from rapidboxes.main import create_app
-from rapidboxes.models import TropismConfig, UpdateApplyResult, UpdateCheckResult
+from rapidboxes.models import ExperimentState, TropismConfig, UpdateApplyResult, UpdateCheckResult
 
 
 @pytest.fixture
@@ -84,6 +84,75 @@ async def test_update_apply_endpoint_delegates_to_updater(client: AsyncClient, m
     body = res.json()
     assert body["status"] == "updated"
     assert body["toCommit"] == "bbb"
+
+
+@pytest.mark.parametrize("state_value", ["running", "paused", "finishing"])
+@pytest.mark.asyncio
+async def test_update_apply_refused_while_experiment_busy(
+    app_config: AppConfig, monkeypatch, state_value: str
+):
+    # "finishing" isn't currently reachable through the real experiment API
+    # (see engine/runner.py -- it's checked but never assigned yet), so this
+    # sets runner.status.state directly rather than driving it via HTTP.
+    called = {"n": 0}
+
+    def fake_apply(branch, repo_root=None):
+        called["n"] += 1
+        return UpdateApplyResult(status="updated", message="should not have been called")
+
+    monkeypatch.setattr("rapidboxes.api.update.apply_update", fake_apply)
+
+    app = create_app(app_config)
+    async with app.router.lifespan_context(app):
+        app.state.app.runner.status.state = ExperimentState(state_value)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            res = await ac.post("/api/system/update/apply")
+            assert res.status_code == 200
+            body = res.json()
+            assert body["status"] == "experiment_active"
+
+    assert called["n"] == 0
+
+
+@pytest.mark.parametrize("state_value", ["idle", "done", "error"])
+@pytest.mark.asyncio
+async def test_update_apply_allowed_while_experiment_not_active(
+    app_config: AppConfig, monkeypatch, state_value: str
+):
+    def fake_apply(branch, repo_root=None):
+        return UpdateApplyResult(status="up_to_date", message="already current")
+
+    monkeypatch.setattr("rapidboxes.api.update.apply_update", fake_apply)
+
+    app = create_app(app_config)
+    async with app.router.lifespan_context(app):
+        app.state.app.runner.status.state = ExperimentState(state_value)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            res = await ac.post("/api/system/update/apply")
+            assert res.status_code == 200
+            assert res.json()["status"] == "up_to_date"
+
+
+@pytest.mark.asyncio
+async def test_update_check_allowed_even_while_experiment_running(
+    app_config: AppConfig, monkeypatch
+):
+    # Read-only -- never gated on experiment state.
+    def fake_check(branch, repo_root=None):
+        return UpdateCheckResult(branch=branch, updateAvailable=True, commitsBehind=1)
+
+    monkeypatch.setattr("rapidboxes.api.update.check_for_update", fake_check)
+
+    app = create_app(app_config)
+    async with app.router.lifespan_context(app):
+        app.state.app.runner.status.state = ExperimentState.running
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            res = await ac.get("/api/system/update/check")
+            assert res.status_code == 200
+            assert res.json()["updateAvailable"] is True
 
 
 @pytest.mark.asyncio

--- a/back/tests/test_api.py
+++ b/back/tests/test_api.py
@@ -8,7 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from rapidboxes.config import AppConfig
 from rapidboxes.main import create_app
-from rapidboxes.models import TropismConfig
+from rapidboxes.models import TropismConfig, UpdateApplyResult, UpdateCheckResult
 
 
 @pytest.fixture
@@ -47,6 +47,43 @@ async def test_system_info(client: AsyncClient):
     assert body["simulation"] is True
     assert "diskFreeBytes" in body
     assert body["cameraAvailable"] is True
+
+
+@pytest.mark.asyncio
+async def test_update_check_endpoint_delegates_to_updater(client: AsyncClient, monkeypatch):
+    # Git plumbing itself is covered against real throwaway repos in
+    # test_updater.py; here we only need to know the route is wired up and
+    # returns whatever the updater reports, for the configured branch.
+    seen = {}
+
+    def fake_check(branch, repo_root=None):
+        seen["branch"] = branch
+        return UpdateCheckResult(
+            branch=branch, updateAvailable=True, commitsBehind=2, commitLog=["abc123 fix"]
+        )
+
+    monkeypatch.setattr("rapidboxes.api.update.check_for_update", fake_check)
+
+    res = await client.get("/api/system/update/check")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["updateAvailable"] is True
+    assert body["commitsBehind"] == 2
+    assert seen["branch"] == "main"  # AppConfig default
+
+
+@pytest.mark.asyncio
+async def test_update_apply_endpoint_delegates_to_updater(client: AsyncClient, monkeypatch):
+    def fake_apply(branch, repo_root=None):
+        return UpdateApplyResult(status="updated", message="ok", fromCommit="aaa", toCommit="bbb")
+
+    monkeypatch.setattr("rapidboxes.api.update.apply_update", fake_apply)
+
+    res = await client.post("/api/system/update/apply")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["status"] == "updated"
+    assert body["toCommit"] == "bbb"
 
 
 @pytest.mark.asyncio

--- a/back/tests/test_updater.py
+++ b/back/tests/test_updater.py
@@ -26,7 +26,9 @@ def _init_repo(path: Path) -> None:
 
 
 def _commit(path: Path, filename: str, content: str, message: str) -> str:
-    (path / filename).write_text(content)
+    target = path / filename
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
     _git(["add", filename], path)
     _git(["commit", "-m", message], path)
     return _git(["rev-parse", "HEAD"], path).strip()
@@ -75,6 +77,8 @@ def test_apply_fast_forwards_local_to_remote(remote_and_local):
     assert result.status == "updated"
     assert result.toCommit == remote_head[:8]
     assert (local / "b.txt").exists()
+    # "b.txt" is at repo root, not under back/ or front/ -- nothing to rebuild.
+    assert result.rebuildStatus == "skipped"
 
     # Idempotent: applying again with nothing new is a no-op, not an error.
     again = apply_update("main", repo_root=local)
@@ -120,3 +124,225 @@ def test_check_reports_error_for_unreachable_remote(tmp_path: Path):
     result = check_for_update("main", repo_root=local)
     assert result.error is not None
     assert result.updateAvailable is False
+
+
+# ---------------------------------------------------------------------------
+# Post-pull rebuild: pip/npm are never actually invoked in these tests --
+# _rebuild_backend / _rebuild_frontend are swapped for fakes so we can assert
+# on *which half* apply_update() decided to rebuild, and how a rebuild
+# failure is surfaced, without needing a real venv/npm toolchain per test.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rebuild_spy(monkeypatch):
+    calls: list[str] = []
+
+    def fake_backend(repo):
+        calls.append("backend")
+
+    def fake_frontend(repo):
+        calls.append("frontend")
+
+    monkeypatch.setattr("rapidboxes.updater._rebuild_backend", fake_backend)
+    monkeypatch.setattr("rapidboxes.updater._rebuild_frontend", fake_frontend)
+    return calls
+
+
+def test_apply_rebuilds_backend_only_when_only_backend_changed(remote_and_local, rebuild_spy):
+    remote, local = remote_and_local
+    _commit(remote, "back/rapidboxes/thing.py", "print(1)", "backend change")
+
+    result = apply_update("main", repo_root=local)
+    assert result.status == "updated"
+    assert result.rebuildStatus == "ok"
+    assert rebuild_spy == ["backend"]
+
+
+def test_apply_rebuilds_frontend_only_when_only_frontend_changed(remote_and_local, rebuild_spy):
+    remote, local = remote_and_local
+    _commit(remote, "front/plant-imaging-controller-faa-main/client/x.tsx", "x", "frontend change")
+
+    result = apply_update("main", repo_root=local)
+    assert result.status == "updated"
+    assert result.rebuildStatus == "ok"
+    assert rebuild_spy == ["frontend"]
+
+
+def test_apply_rebuilds_both_when_both_changed(remote_and_local, rebuild_spy):
+    remote, local = remote_and_local
+    _commit(remote, "back/rapidboxes/thing.py", "print(1)", "backend change")
+    _commit(remote, "front/plant-imaging-controller-faa-main/client/x.tsx", "x", "frontend change")
+
+    result = apply_update("main", repo_root=local)
+    assert result.status == "updated"
+    assert result.rebuildStatus == "ok"
+    assert set(rebuild_spy) == {"backend", "frontend"}
+
+
+def test_apply_skips_rebuild_when_neither_back_nor_front_changed(remote_and_local, rebuild_spy):
+    remote, local = remote_and_local
+    _commit(remote, "deploy/README.txt", "notes", "docs-only change")
+
+    result = apply_update("main", repo_root=local)
+    assert result.status == "updated"
+    assert result.rebuildStatus == "skipped"
+    assert rebuild_spy == []
+
+
+def test_apply_reports_rebuild_failure_distinctly_without_reverting_the_pull(
+    remote_and_local, monkeypatch
+):
+    from rapidboxes.updater import UpdaterError
+
+    remote, local = remote_and_local
+    remote_head = _commit(remote, "front/plant-imaging-controller-faa-main/client/x.tsx", "x", "fe change")
+
+    def failing_frontend(repo):
+        raise UpdaterError("npm run build exploded")
+
+    monkeypatch.setattr("rapidboxes.updater._rebuild_frontend", failing_frontend)
+
+    result = apply_update("main", repo_root=local)
+    # The git pull itself still succeeded -- that's not undone by a rebuild
+    # failure -- but the rebuild outcome is surfaced distinctly so callers
+    # know not to treat this as a clean, restart-ready success.
+    assert result.status == "updated"
+    assert result.toCommit == remote_head[:8]
+    assert result.rebuildStatus == "failed"
+    assert "npm run build exploded" in result.rebuildMessage
+    assert (local / "front/plant-imaging-controller-faa-main/client/x.tsx").exists()
+
+
+# ---------------------------------------------------------------------------
+# CLI: experiment-active gate + restart-on-rebuild-failure behaviour.
+# apply_update() itself is faked here (already covered above / by the
+# fast-forward tests) so these focus purely on main()'s control flow.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cli_config(tmp_path, monkeypatch):
+    from rapidboxes.config import AppConfig
+
+    config = AppConfig(
+        simulation=True,
+        storage_root=tmp_path / "experiments",
+        settings_path=tmp_path / "settings.json",
+        spa_dir=None,
+    )
+    monkeypatch.setattr("rapidboxes.config.get_config", lambda: config)
+    return config
+
+
+def test_cli_apply_refuses_when_experiment_active(monkeypatch, capsys, cli_config):
+    from rapidboxes import updater
+
+    monkeypatch.setattr(updater, "check_experiment_active_via_http", lambda port, timeout=5.0: True)
+    called = {"n": 0}
+
+    def fake_apply(branch, repo_root=None):
+        called["n"] += 1
+        return updater.UpdateApplyResult(status="updated", message="should not run")
+
+    monkeypatch.setattr(updater, "apply_update", fake_apply)
+
+    rc = updater.main(["apply"])
+    assert rc == 1
+    assert called["n"] == 0
+    assert '"experiment_active"' in capsys.readouterr().out
+
+
+def test_cli_apply_proceeds_when_experiment_not_active(monkeypatch, capsys, cli_config):
+    from rapidboxes import updater
+
+    monkeypatch.setattr(updater, "check_experiment_active_via_http", lambda port, timeout=5.0: False)
+
+    def fake_apply(branch, repo_root=None):
+        return updater.UpdateApplyResult(status="up_to_date", message="already current")
+
+    monkeypatch.setattr(updater, "apply_update", fake_apply)
+
+    rc = updater.main(["apply"])
+    assert rc == 0
+    assert '"up_to_date"' in capsys.readouterr().out
+
+
+def test_cli_triggers_restart_after_successful_pull_and_rebuild(monkeypatch, cli_config):
+    from rapidboxes import updater
+
+    monkeypatch.setattr(updater, "check_experiment_active_via_http", lambda port, timeout=5.0: False)
+
+    def fake_apply(branch, repo_root=None):
+        return updater.UpdateApplyResult(
+            status="updated", message="ok", fromCommit="a", toCommit="b",
+            rebuildStatus="ok", rebuildMessage="rebuilt",
+        )
+
+    monkeypatch.setattr(updater, "apply_update", fake_apply)
+    restarts = {"n": 0}
+    monkeypatch.setattr(updater, "_trigger_restart", lambda port: restarts.__setitem__("n", restarts["n"] + 1))
+
+    rc = updater.main(["apply", "--restart-on-success"])
+    assert rc == 0
+    assert restarts["n"] == 1
+
+
+def test_cli_does_not_restart_when_rebuild_failed(monkeypatch, capsys, cli_config):
+    from rapidboxes import updater
+
+    monkeypatch.setattr(updater, "check_experiment_active_via_http", lambda port, timeout=5.0: False)
+
+    def fake_apply(branch, repo_root=None):
+        return updater.UpdateApplyResult(
+            status="updated", message="ok", fromCommit="a", toCommit="b",
+            rebuildStatus="failed", rebuildMessage="npm blew up",
+        )
+
+    monkeypatch.setattr(updater, "apply_update", fake_apply)
+    restarts = {"n": 0}
+    monkeypatch.setattr(updater, "_trigger_restart", lambda port: restarts.__setitem__("n", restarts["n"] + 1))
+
+    rc = updater.main(["apply", "--restart-on-success"])
+    assert rc == 2
+    assert restarts["n"] == 0
+    assert "NOT restarting" in capsys.readouterr().err
+
+
+def test_check_experiment_active_via_http_reports_busy_states(monkeypatch):
+    import json
+
+    from rapidboxes import updater
+
+    class FakeResponse:
+        def __init__(self, body):
+            self._body = json.dumps(body).encode()
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda req, timeout=None: FakeResponse({"state": "paused"})
+    )
+    assert updater.check_experiment_active_via_http(8000) is True
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda req, timeout=None: FakeResponse({"state": "idle"})
+    )
+    assert updater.check_experiment_active_via_http(8000) is False
+
+
+def test_check_experiment_active_via_http_treats_unreachable_server_as_active(monkeypatch):
+    from rapidboxes import updater
+
+    def raise_connection_error(req, timeout=None):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", raise_connection_error)
+    assert updater.check_experiment_active_via_http(8000) is True

--- a/back/tests/test_updater.py
+++ b/back/tests/test_updater.py
@@ -1,0 +1,122 @@
+"""Exercises the OTA updater against real throwaway git repos (no mocking of
+git itself -- we want to know the actual fetch/ff-only-merge behaviour is
+correct, including the refusal paths)."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from rapidboxes.updater import apply_update, check_for_update
+
+
+def _git(args, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=str(cwd), capture_output=True, text=True, check=True
+    )
+    return result.stdout
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(["init", "-b", "main"], path)
+    _git(["config", "user.email", "test@example.com"], path)
+    _git(["config", "user.name", "Test"], path)
+
+
+def _commit(path: Path, filename: str, content: str, message: str) -> str:
+    (path / filename).write_text(content)
+    _git(["add", filename], path)
+    _git(["commit", "-m", message], path)
+    return _git(["rev-parse", "HEAD"], path).strip()
+
+
+@pytest.fixture
+def remote_and_local(tmp_path: Path):
+    remote = tmp_path / "remote"
+    _init_repo(remote)
+    _commit(remote, "a.txt", "1", "initial")
+
+    local = tmp_path / "local"
+    _git(["clone", str(remote), str(local)], tmp_path)
+    _git(["config", "user.email", "test@example.com"], local)
+    _git(["config", "user.name", "Test"], local)
+
+    return remote, local
+
+
+def test_check_reports_up_to_date_right_after_clone(remote_and_local):
+    _remote, local = remote_and_local
+    result = check_for_update("main", repo_root=local)
+    assert result.error is None
+    assert result.updateAvailable is False
+    assert result.commitsBehind == 0
+
+
+def test_check_reports_available_update_with_commit_log(remote_and_local):
+    remote, local = remote_and_local
+    _commit(remote, "b.txt", "2", "second commit")
+    _commit(remote, "c.txt", "3", "third commit")
+
+    result = check_for_update("main", repo_root=local)
+    assert result.error is None
+    assert result.updateAvailable is True
+    assert result.commitsBehind == 2
+    assert len(result.commitLog) == 2
+    assert "third commit" in result.commitLog[0]
+
+
+def test_apply_fast_forwards_local_to_remote(remote_and_local):
+    remote, local = remote_and_local
+    remote_head = _commit(remote, "b.txt", "2", "second commit")
+
+    result = apply_update("main", repo_root=local)
+    assert result.status == "updated"
+    assert result.toCommit == remote_head[:8]
+    assert (local / "b.txt").exists()
+
+    # Idempotent: applying again with nothing new is a no-op, not an error.
+    again = apply_update("main", repo_root=local)
+    assert again.status == "up_to_date"
+
+
+def test_apply_refuses_when_working_tree_is_dirty(remote_and_local):
+    remote, local = remote_and_local
+    _commit(remote, "b.txt", "2", "second commit")
+
+    (local / "a.txt").write_text("locally modified, uncommitted")
+
+    result = apply_update("main", repo_root=local)
+    assert result.status == "error"
+    assert "local changes" in result.message
+
+    # Nothing was pulled -- HEAD is unchanged and the dirty file is untouched.
+    head = _git(["rev-parse", "HEAD"], local).strip()
+    check = check_for_update("main", repo_root=local)
+    assert head != check.remoteCommit
+    assert (local / "a.txt").read_text() == "locally modified, uncommitted"
+
+
+def test_apply_refuses_when_history_has_diverged(remote_and_local):
+    remote, local = remote_and_local
+    _commit(remote, "b.txt", "2", "remote-only commit")
+    _commit(local, "c.txt", "3", "local-only commit")
+
+    result = apply_update("main", repo_root=local)
+    assert result.status == "error"
+    assert "diverged" in result.message.lower()
+
+    # The local-only commit is still there -- no reset/rebase was attempted.
+    assert (local / "c.txt").exists()
+
+
+def test_check_reports_error_for_unreachable_remote(tmp_path: Path):
+    # A repo with no "origin" remote at all -- `git fetch origin` fails cleanly.
+    local = tmp_path / "solo"
+    _init_repo(local)
+    _commit(local, "a.txt", "1", "initial")
+
+    result = check_for_update("main", repo_root=local)
+    assert result.error is not None
+    assert result.updateAvailable is False

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -59,6 +59,13 @@ python3 -m venv --system-site-packages "$VENV"
 echo "==> Building the UI bundle..."
 ( cd "$FRONT_DIR" && npm install --no-audit --no-fund && npm run build )
 
+# OTA self-update (Settings -> General "Update" button + the monthly timer)
+# tracks whatever branch is actually checked out right now, not a hardcoded
+# "main" -- this repo is developed on "v2" while "main" is the older/stable
+# branch, and a given box may be deliberately pinned elsewhere. Override
+# later by editing RAPIDBOXES_UPDATE_BRANCH in /etc/rapidboxes.env.
+UPDATE_BRANCH="$(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo main)"
+
 echo "==> Writing /etc/rapidboxes.env..."
 sudo tee /etc/rapidboxes.env >/dev/null <<EOF
 RAPIDBOXES_SIMULATION=0
@@ -67,6 +74,7 @@ RAPIDBOXES_PORT=$PORT
 RAPIDBOXES_SPA_DIR=$FRONT_DIR/dist/spa
 RAPIDBOXES_STORAGE_ROOT=$HOME_DIR/rapidboxes/experiments
 RAPIDBOXES_SETTINGS_PATH=$HOME_DIR/rapidboxes/settings.json
+RAPIDBOXES_UPDATE_BRANCH=$UPDATE_BRANCH
 EOF
 
 echo "==> Installing systemd service..."
@@ -76,6 +84,15 @@ sed -e "s|@USER@|$RUN_USER|g" \
     "$REPO_DIR/deploy/rapidboxes.service" | sudo tee /etc/systemd/system/rapidboxes.service >/dev/null
 sudo systemctl daemon-reload
 sudo systemctl enable --now rapidboxes.service
+
+echo "==> Installing monthly OTA self-update timer..."
+sed -e "s|@USER@|$RUN_USER|g" \
+    -e "s|@BACK_DIR@|$BACK_DIR|g" \
+    -e "s|@VENV@|$VENV|g" \
+    "$REPO_DIR/deploy/rapidboxes-update.service" | sudo tee /etc/systemd/system/rapidboxes-update.service >/dev/null
+sudo cp "$REPO_DIR/deploy/rapidboxes-update.timer" /etc/systemd/system/rapidboxes-update.timer
+sudo systemctl daemon-reload
+sudo systemctl enable --now rapidboxes-update.timer
 
 echo "==> Installing Chromium kiosk autostart..."
 chmod +x "$REPO_DIR/deploy/kiosk.sh"
@@ -93,8 +110,10 @@ sed "s|@IDLE_SH@|$REPO_DIR/deploy/idle.sh|g" \
 cat <<EOF
 
 ==> Done.
-    Backend:  systemctl status rapidboxes      (http://localhost:$PORT)
+    Backend:  systemctl status rapidboxes            (http://localhost:$PORT)
     Logs:     journalctl -u rapidboxes -f
+    OTA:      systemctl list-timers rapidboxes-update  (tracks branch: $UPDATE_BRANCH)
+              journalctl -u rapidboxes-update -f
     Reboot to apply SPI/camera/group changes and launch the kiosk:
         sudo reboot
 EOF

--- a/deploy/rapidboxes-update.service
+++ b/deploy/rapidboxes-update.service
@@ -8,12 +8,19 @@ Type=oneshot
 User=@USER@
 WorkingDirectory=@BACK_DIR@
 EnvironmentFile=/etc/rapidboxes.env
-# Same git fetch + `merge --ff-only` logic as the manual Settings -> General
-# "Update" button (rapidboxes/updater.py). No user is present to confirm a
-# restart here, so on a successful pull this asks the already-running
+# Same git fetch + `merge --ff-only` (+ post-pull rebuild) logic as the
+# manual Settings -> General "Update" button (rapidboxes/updater.py). Refuses
+# outright if an experiment looks running/paused/finishing (checked over
+# loopback HTTP against the live service, since this is a separate process)
+# -- see check_experiment_active_via_http() -- rather than risk interrupting
+# a multi-day protocol; Persistent=true on the timer plus next month's run
+# cover a skipped month. No user is present to confirm a restart here, so on
+# a successful pull *and* successful rebuild this asks the already-running
 # rapidboxes.service to restart itself over loopback HTTP (POST
 # /api/system/restart-service) -- the same path the manual button uses after
-# the user confirms. That endpoint just kills its own process and relies on
-# rapidboxes.service's Restart=always, so this unit needs no systemctl/sudo
-# access of its own.
+# the user confirms. If the rebuild fails, it deliberately does NOT restart
+# (that would leave the service running mismatched code/deps); check
+# `journalctl -u rapidboxes-update` for the warning. That restart endpoint
+# just kills its own process and relies on rapidboxes.service's
+# Restart=always, so this unit needs no systemctl/sudo access of its own.
 ExecStart=@VENV@/bin/python -m rapidboxes.updater apply --restart-on-success

--- a/deploy/rapidboxes-update.service
+++ b/deploy/rapidboxes-update.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=RaPiD-boxes OTA self-update (git fetch + fast-forward-only pull)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=@USER@
+WorkingDirectory=@BACK_DIR@
+EnvironmentFile=/etc/rapidboxes.env
+# Same git fetch + `merge --ff-only` logic as the manual Settings -> General
+# "Update" button (rapidboxes/updater.py). No user is present to confirm a
+# restart here, so on a successful pull this asks the already-running
+# rapidboxes.service to restart itself over loopback HTTP (POST
+# /api/system/restart-service) -- the same path the manual button uses after
+# the user confirms. That endpoint just kills its own process and relies on
+# rapidboxes.service's Restart=always, so this unit needs no systemctl/sudo
+# access of its own.
+ExecStart=@VENV@/bin/python -m rapidboxes.updater apply --restart-on-success

--- a/deploy/rapidboxes-update.timer
+++ b/deploy/rapidboxes-update.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Run the RaPiD-boxes OTA self-update monthly
+
+[Timer]
+# Once a month, at 3am local time -- a low-activity hour unlikely to land
+# mid-capture, and far enough from midnight to dodge most cron/log-rotate
+# contention. RandomizedDelaySec spreads a fleet of boxes out instead of
+# every device hitting origin at the same instant. Persistent=true means a
+# box that's powered off at 3am on the 1st runs the check on its next boot
+# instead of silently skipping a whole month.
+OnCalendar=*-*-01 03:00:00
+RandomizedDelaySec=1800
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/uninstall.sh
+++ b/deploy/uninstall.sh
@@ -6,7 +6,9 @@ RUN_USER="${SUDO_USER:-$USER}"
 HOME_DIR="$(eval echo "~$RUN_USER")"
 
 sudo systemctl disable --now rapidboxes.service 2>/dev/null || true
+sudo systemctl disable --now rapidboxes-update.timer 2>/dev/null || true
 sudo rm -f /etc/systemd/system/rapidboxes.service /etc/rapidboxes.env
+sudo rm -f /etc/systemd/system/rapidboxes-update.service /etc/systemd/system/rapidboxes-update.timer
 sudo systemctl daemon-reload
 rm -f "$HOME_DIR/.config/autostart/rapidboxes-kiosk.desktop"
 rm -f "$HOME_DIR/.config/autostart/rapidboxes-idle.desktop"

--- a/front/plant-imaging-controller-faa-main/client/components/GeneralSettingsMenu.tsx
+++ b/front/plant-imaging-controller-faa-main/client/components/GeneralSettingsMenu.tsx
@@ -1,4 +1,5 @@
 import { useSystemInfo } from "@/hooks/useSystemInfo";
+import UpdatePanel from "@/components/UpdatePanel";
 
 const LOW_DISK_BYTES = 2 * 1024 * 1024 * 1024;
 
@@ -80,6 +81,8 @@ export default function GeneralSettingsMenu() {
               </p>
             )}
           </div>
+
+          <UpdatePanel />
         </div>
       </div>
     </div>

--- a/front/plant-imaging-controller-faa-main/client/components/UpdatePanel.tsx
+++ b/front/plant-imaging-controller-faa-main/client/components/UpdatePanel.tsx
@@ -48,13 +48,28 @@ export default function UpdatePanel() {
     setPhase("applying");
     try {
       const result = await api.applyUpdate();
-      if (result.status === "error") {
+      if (result.status === "error" || result.status === "experiment_active") {
         toast.error(result.message);
         setPhase("available");
         return;
       }
       if (result.status === "up_to_date") {
         toast.success("Already up to date.");
+        setCheck(null);
+        setPhase("idle");
+        return;
+      }
+      // status === "updated"
+      if (result.rebuildStatus === "failed") {
+        // The git pull succeeded but the dependency/build step didn't --
+        // code and installed deps are now mismatched. Don't offer to
+        // restart into that; surface it clearly so a human can SSH in and
+        // finish the job (e.g. deploy/update.sh) instead.
+        toast.error(
+          `Update pulled but the rebuild failed: ${result.rebuildMessage ?? "unknown error"}. ` +
+            "Do not restart until this is resolved manually.",
+          { duration: 15000 },
+        );
         setCheck(null);
         setPhase("idle");
         return;

--- a/front/plant-imaging-controller-faa-main/client/components/UpdatePanel.tsx
+++ b/front/plant-imaging-controller-faa-main/client/components/UpdatePanel.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import { RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+import { restartAppToHome } from "@/lib/restartApp";
+import type { UpdateCheckResult } from "@shared/api";
+
+/**
+ * OTA self-update card for Settings -> General. Two-step, both explicit:
+ * "Check for Updates" only fetches + compares (never touches the working
+ * tree); "Update Now" does the fast-forward-only pull. The same monthly
+ * unattended check (deploy/rapidboxes-update.timer) runs the identical git
+ * logic headlessly and restarts automatically on success -- here a human is
+ * present, so we ask before restarting instead.
+ */
+type Phase = "idle" | "checking" | "available" | "applying" | "restart-prompt";
+
+export default function UpdatePanel() {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [check, setCheck] = useState<UpdateCheckResult | null>(null);
+  const [restarting, setRestarting] = useState(false);
+
+  const handleCheck = async () => {
+    if (phase === "checking" || phase === "applying") return;
+    setPhase("checking");
+    try {
+      const result = await api.checkForUpdate();
+      if (result.error) {
+        toast.error(`Update check failed: ${result.error}`);
+        setPhase("idle");
+        return;
+      }
+      if (!result.updateAvailable) {
+        toast.success(`Up to date (origin/${result.branch}).`);
+        setCheck(null);
+        setPhase("idle");
+        return;
+      }
+      setCheck(result);
+      setPhase("available");
+    } catch (e) {
+      toast.error(`Update check failed: ${(e as Error).message}`);
+      setPhase("idle");
+    }
+  };
+
+  const handleApply = async () => {
+    setPhase("applying");
+    try {
+      const result = await api.applyUpdate();
+      if (result.status === "error") {
+        toast.error(result.message);
+        setPhase("available");
+        return;
+      }
+      if (result.status === "up_to_date") {
+        toast.success("Already up to date.");
+        setCheck(null);
+        setPhase("idle");
+        return;
+      }
+      setPhase("restart-prompt");
+    } catch (e) {
+      toast.error(`Update failed: ${(e as Error).message}`);
+      setPhase("available");
+    }
+  };
+
+  const dismiss = () => {
+    setCheck(null);
+    setPhase("idle");
+  };
+
+  return (
+    <div className="rounded-[10px] border border-app-border-primary bg-app-bg-secondary p-3">
+      <div className="text-[10px] font-bold uppercase tracking-[0.5px] text-app-text-muted">
+        Software Update
+      </div>
+
+      {phase !== "available" && phase !== "applying" && (
+        <button
+          onClick={handleCheck}
+          disabled={phase === "checking"}
+          className="mt-2 flex w-full items-center justify-center gap-2 rounded-md bg-app-bg-tertiary py-2 text-[12px] font-semibold text-white transition-colors hover:bg-app-border-primary disabled:opacity-60"
+        >
+          <RefreshCw
+            className={`h-[14px] w-[14px] ${phase === "checking" ? "animate-spin" : ""}`}
+            strokeWidth={1.75}
+          />
+          {phase === "checking" ? "Checking…" : "Check for Updates"}
+        </button>
+      )}
+
+      {(phase === "available" || phase === "applying") && check && (
+        <div className="mt-2 rounded-md border border-app-green/40 bg-app-green/10 p-2.5">
+          <p className="text-[11px] font-semibold text-white">
+            {check.commitsBehind} commit{check.commitsBehind === 1 ? "" : "s"} behind{" "}
+            origin/{check.branch}
+          </p>
+          {check.commitLog.length > 0 && (
+            <ul className="mt-1.5 max-h-24 space-y-0.5 overflow-y-auto text-[10px] text-app-text-muted">
+              {check.commitLog.map((line, i) => (
+                <li key={i} className="truncate">
+                  {line}
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="mt-2 flex gap-2">
+            <button
+              onClick={handleApply}
+              disabled={phase === "applying"}
+              className="flex-1 rounded-md bg-app-green py-1.5 text-[11px] font-bold uppercase tracking-wide text-white transition-opacity hover:opacity-90 disabled:opacity-60"
+            >
+              {phase === "applying" ? "Updating…" : "Update Now"}
+            </button>
+            <button
+              onClick={dismiss}
+              disabled={phase === "applying"}
+              className="flex-1 rounded-md bg-app-bg-tertiary py-1.5 text-[11px] font-semibold text-app-text-secondary transition-colors hover:bg-app-border-primary disabled:opacity-60"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+
+      {phase === "restart-prompt" && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 p-4">
+          <div className="w-full max-w-[360px] rounded-xl border border-app-border-primary bg-app-bg-secondary p-4 shadow-2xl">
+            <p className="text-[13px] font-bold text-white">Update installed</p>
+            <p className="mt-1 text-[12px] text-app-text-muted">
+              Restart now to apply changes?
+            </p>
+            <div className="mt-3 flex gap-2">
+              <button
+                onClick={() => restartAppToHome(setRestarting)}
+                disabled={restarting}
+                className="flex-1 rounded-md bg-app-green py-2 text-[12px] font-bold uppercase tracking-wide text-white transition-opacity hover:opacity-90 disabled:opacity-60"
+              >
+                {restarting ? "Restarting…" : "Restart"}
+              </button>
+              <button
+                onClick={() => {
+                  setCheck(null);
+                  setPhase("idle");
+                }}
+                disabled={restarting}
+                className="flex-1 rounded-md bg-app-bg-tertiary py-2 text-[12px] font-semibold text-app-text-secondary transition-colors hover:bg-app-border-primary disabled:opacity-60"
+              >
+                Later
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/plant-imaging-controller-faa-main/client/lib/api.ts
+++ b/front/plant-imaging-controller-faa-main/client/lib/api.ts
@@ -9,6 +9,8 @@ import type {
   SavedExperimentConfig,
   StartResponse,
   SystemInfo,
+  UpdateApplyResult,
+  UpdateCheckResult,
 } from "@shared/api";
 
 async function errorDetail(res: Response): Promise<string> {
@@ -56,6 +58,8 @@ export const api = {
   recheckCamera: () => jsonFetch<SystemInfo>("/api/system/recheck-camera", { method: "POST" }),
   closeKiosk: () => jsonFetch<{ status: string; kioskPids: number[] }>("/api/system/close-kiosk", { method: "POST" }),
   restartService: () => jsonFetch<{ status: string }>("/api/system/restart-service", { method: "POST" }),
+  checkForUpdate: () => jsonFetch<UpdateCheckResult>("/api/system/update/check"),
+  applyUpdate: () => jsonFetch<UpdateApplyResult>("/api/system/update/apply", { method: "POST" }),
   testPhotoWithSettings: async (settings: CameraSettings): Promise<Blob> => {
     const res = await fetch("/api/preview/test-photo", {
       method: "POST",

--- a/front/plant-imaging-controller-faa-main/shared/api.ts
+++ b/front/plant-imaging-controller-faa-main/shared/api.ts
@@ -119,10 +119,15 @@ export interface UpdateCheckResult {
 }
 
 export interface UpdateApplyResult {
-  status: "updated" | "up_to_date" | "error";
+  status: "updated" | "up_to_date" | "error" | "experiment_active";
   message: string;
   fromCommit: string | null;
   toCommit: string | null;
+  // Set only when status === "updated". "failed" means the pull itself
+  // succeeded but the post-pull dependency/build step did not -- code and
+  // installed deps are now mismatched, a worse state than a clean refusal.
+  rebuildStatus: "skipped" | "ok" | "failed" | null;
+  rebuildMessage: string | null;
 }
 
 export interface CameraSettings {

--- a/front/plant-imaging-controller-faa-main/shared/api.ts
+++ b/front/plant-imaging-controller-faa-main/shared/api.ts
@@ -107,6 +107,24 @@ export interface SystemInfo {
   cameraAvailable: boolean;
 }
 
+// OTA self-update (Settings -> General -> Update button).
+export interface UpdateCheckResult {
+  branch: string;
+  updateAvailable: boolean;
+  currentCommit: string | null;
+  remoteCommit: string | null;
+  commitsBehind: number;
+  commitLog: string[];
+  error: string | null;
+}
+
+export interface UpdateApplyResult {
+  status: "updated" | "up_to_date" | "error";
+  message: string;
+  fromCommit: string | null;
+  toCommit: string | null;
+}
+
 export interface CameraSettings {
   width: number;
   height: number;


### PR DESCRIPTION
Adds a Settings -> General "Update" card and an unattended monthly systemd timer, both backed by the same git-only fast-forward logic (never `reset --hard`).

- Checks/pulls from `origin/main` by default (configurable via `RAPIDBOXES_UPDATE_BRANCH`)
- Refuses cleanly on a dirty working tree or diverged history -- no destructive git ops
- Rebuilds only what changed (`pip install` for `back/`, `npm install && npm run build` for `front/`), mirroring `deploy/update.sh`
- Refuses to update while an experiment is running/paused/finishing (manual: in-process check; monthly timer: loopback HTTP check against the running service, fails safe to "active" if unreachable)
- On manual apply, prompts "Restart now?"; the monthly timer restarts automatically only if the rebuild also succeeded

62 backend tests pass; `npm run typecheck`/`npm run build` pass.