### PR TITLE
Version history + rollback, SSH info card, fix ETA float-precision bug

### DIFF
--- a/back/rapidboxes/api/system.py
+++ b/back/rapidboxes/api/system.py
@@ -7,6 +7,8 @@ import signal
 import subprocess
 import shutil
 import socket
+import time
+from typing import Tuple
 
 from fastapi import APIRouter, Depends
 
@@ -28,6 +30,61 @@ def _local_ip() -> str:
         return "127.0.0.1"
 
 
+def _ssh_user() -> str:
+    """The account SSH would log into -- same one rapidboxes.service runs as
+    (User=@USER@ in deploy/rapidboxes.service), read in-process rather than
+    from config since it needs no new setting."""
+    try:
+        import pwd
+
+        return pwd.getpwuid(os.getuid()).pw_name
+    except Exception:
+        return os.environ.get("USER", "")
+
+
+# /api/system is polled every 5s by the kiosk (see useSystemInfo); SSH
+# enabled/disabled essentially never changes at runtime, so cache the
+# subprocess result briefly rather than forking `systemctl` on every poll.
+_SSH_ENABLED_CACHE_S = 30.0
+_ssh_enabled_cache: Tuple[float, bool] = (0.0, False)
+
+
+def _ssh_enabled() -> bool:
+    """Whether openssh-server is actually reachable right now.
+
+    Raspberry Pi OS (Debian-based, Bookworm included) registers the openssh
+    server as the systemd unit `ssh.service`, not `sshd.service` -- confirmed
+    against Raspberry Pi OS Bookworm docs/forums, which consistently use
+    `systemctl enable ssh` / `systemctl status ssh` (unit description "OpenBSD
+    Secure Shell server"); `sshd` is not the unit name there even though the
+    daemon binary itself is /usr/sbin/sshd. `is-active` (not `is-enabled`) is
+    used because what the UI cares about is "can I ssh in right now", not
+    just whether it's set to start on boot -- and both are queryable as a
+    non-root user. On a dev laptop without systemd (e.g. macOS), this just
+    fails closed to False.
+    """
+    global _ssh_enabled_cache
+    checked_at, cached = _ssh_enabled_cache
+    now = time.monotonic()
+    if now - checked_at < _SSH_ENABLED_CACHE_S:
+        return cached
+
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-active", "ssh"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        enabled = result.stdout.strip() == "active"
+    except Exception:
+        enabled = False
+
+    _ssh_enabled_cache = (now, enabled)
+    return enabled
+
+
 def _info(state: AppState) -> SystemInfo:
     usage = shutil.disk_usage(state.config.storage_root)
     return SystemInfo(
@@ -39,6 +96,8 @@ def _info(state: AppState) -> SystemInfo:
         diskFreeBytes=usage.free,
         diskTotalBytes=usage.total,
         cameraAvailable=state.hw.camera_available,
+        sshUser=_ssh_user(),
+        sshEnabled=_ssh_enabled(),
     )
 
 

--- a/back/rapidboxes/api/update.py
+++ b/back/rapidboxes/api/update.py
@@ -1,19 +1,21 @@
-"""OTA self-update endpoints for the Settings -> General "Update" button.
+"""OTA self-update endpoints for the Settings -> General "Update"/"Version" cards.
 
-Both endpoints only ever fetch + fast-forward-merge (see ../updater.py); they
-never reset or discard local changes. Applying an update does not restart the
+check/apply only ever fetch + fast-forward-merge; rollback only ever
+`git checkout --detach` to a previously-recorded commit (see ../updater.py
+for why that's used instead of `git reset --hard`). None of them restart the
 service itself -- the frontend shows a "restart now?" dialog after a
-successful apply and, on confirm, calls the existing POST
+successful apply/rollback and, on confirm, calls the existing POST
 /api/system/restart-service endpoint (see api/system.py).
 """
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 
 from fastapi import APIRouter, Depends
 
-from ..models import UpdateApplyResult, UpdateCheckResult
-from ..updater import BUSY_EXPERIMENT_STATES, apply_update, check_for_update
+from ..models import UpdateApplyResult, UpdateCheckResult, VersionStatus
+from ..updater import BUSY_EXPERIMENT_STATES, apply_update, check_for_update, get_version_status, rollback_update
 from .deps import AppState, get_state
 
 router = APIRouter(prefix="/api/system/update", tags=["update"])
@@ -28,6 +30,17 @@ async def check(state: AppState = Depends(get_state)):
     # git fetch does network I/O; run off the event loop so it can't stall
     # the WS status feed / MJPEG preview during an active experiment.
     return await asyncio.to_thread(check_for_update, state.config.update_branch)
+
+
+@router.get("/version", response_model=VersionStatus)
+async def version(state: AppState = Depends(get_state)):
+    """Currently-running commit + how long, and the previous one (if any).
+
+    Read-only (may lazily write a single "seed" history entry the very first
+    time it's called on a box with no history yet -- see
+    updater.get_version_status) -- always allowed, even mid-experiment.
+    """
+    return await asyncio.to_thread(get_version_status, state.config.update_history_path)
 
 
 @router.post("/apply", response_model=UpdateApplyResult)
@@ -45,4 +58,28 @@ async def apply(state: AppState = Depends(get_state)):
             status="experiment_active",
             message="Finish or stop the current experiment before updating.",
         )
-    return await asyncio.to_thread(apply_update, state.config.update_branch)
+    return await asyncio.to_thread(
+        partial(
+            apply_update,
+            state.config.update_branch,
+            history_path=state.config.update_history_path,
+            trigger="manual",
+        )
+    )
+
+
+@router.post("/rollback", response_model=UpdateApplyResult)
+async def rollback(state: AppState = Depends(get_state)):
+    """Move the working tree back to the previously-recorded commit.
+
+    Same busy-experiment gate as apply(); see updater.rollback_update() for
+    why this uses `git checkout --detach` rather than `git reset --hard`, and
+    why the frontend surfaces a warning that a monthly auto-update tracking
+    the same branch can fast-forward straight back onto a rolled-back commit.
+    """
+    if state.runner.status.state in BUSY_EXPERIMENT_STATES:
+        return UpdateApplyResult(
+            status="experiment_active",
+            message="Finish or stop the current experiment before rolling back.",
+        )
+    return await asyncio.to_thread(partial(rollback_update, state.config.update_history_path))

--- a/back/rapidboxes/config.py
+++ b/back/rapidboxes/config.py
@@ -67,6 +67,12 @@ class AppConfig(BaseSettings):
     # blindly against origin/main.
     update_branch: str = "main"
 
+    # Record of applied OTA updates/rollbacks (see rapidboxes/update_history.py),
+    # used by Settings -> General -> Version to show "running commit X for Y"
+    # and to know what the "Roll back" button targets. Same directory
+    # convention as settings_path.
+    update_history_path: Path = Path.home() / "rapidboxes" / "update_history.json"
+
     def ensure_dirs(self) -> None:
         self.storage_root.mkdir(parents=True, exist_ok=True)
         self.settings_path.parent.mkdir(parents=True, exist_ok=True)

--- a/back/rapidboxes/models.py
+++ b/back/rapidboxes/models.py
@@ -323,17 +323,35 @@ class UpdateCheckResult(BaseModel):
 
 
 class UpdateApplyResult(BaseModel):
-    status: str  # "updated" | "up_to_date" | "error" | "experiment_active"
+    # "updated" | "up_to_date" | "error" | "experiment_active"
+    # | "rolled_back" | "nothing_to_roll_back_to" (rollback only)
+    status: str
     message: str
     fromCommit: Optional[str] = None
     toCommit: Optional[str] = None
-    # Set only when status == "updated": whether the post-pull dependency /
-    # frontend-build step ran, and how it went. "failed" means the git pull
-    # succeeded but the running process is now on mismatched code/deps -- a
-    # worse state than a clean refusal, so callers must NOT treat this as a
-    # green light to restart (see updater.py).
+    # Set only when status in ("updated", "rolled_back"): whether the
+    # post-move dependency / frontend-build step ran, and how it went.
+    # "failed" means the git move succeeded but the running process is now on
+    # mismatched code/deps -- a worse state than a clean refusal, so callers
+    # must NOT treat this as a green light to restart (see updater.py).
     rebuildStatus: Optional[str] = None  # None | "skipped" | "ok" | "failed"
     rebuildMessage: Optional[str] = None
+
+
+class UpdateHistoryEntry(BaseModel):
+    """One row in update_history.json: a commit that became HEAD, and why."""
+
+    commit: str  # short hash (8 chars), consistent with fromCommit/toCommit above
+    appliedAt: datetime
+    trigger: str  # "manual" | "monthly" | "rollback" | "seed"
+
+
+class VersionStatus(BaseModel):
+    """What Settings -> General -> Version shows: current + (if any) previous."""
+
+    current: Optional[UpdateHistoryEntry] = None
+    previous: Optional[UpdateHistoryEntry] = None
+    error: Optional[str] = None
 
 
 class StartResponse(BaseModel):

--- a/back/rapidboxes/models.py
+++ b/back/rapidboxes/models.py
@@ -303,6 +303,12 @@ class SystemInfo(BaseModel):
     diskFreeBytes: int
     diskTotalBytes: int
     cameraAvailable: bool = True
+    # Settings -> General -> SSH Access. sshUser is the account `rapidboxes.
+    # service` runs as (User=@USER@ in deploy/rapidboxes.service) -- the same
+    # account SSH would log into. sshEnabled reflects whether the openssh
+    # server is actually reachable right now (see api/system.py).
+    sshUser: str = ""
+    sshEnabled: bool = False
 
 
 # ---------------------------------------------------------------------------

--- a/back/rapidboxes/update_history.py
+++ b/back/rapidboxes/update_history.py
@@ -1,0 +1,50 @@
+"""Persist the OTA update history as JSON (atomic write).
+
+Same convention as settings_store.py: a small JSON file under the user's
+`~/rapidboxes/` directory, read/modified/written as a whole rather than a
+database. This one holds a short list rather than a single object, since the
+UI needs to know both the current entry (what commit, applied when, by what
+trigger) and the previous one (what the "Roll back" button targets).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import List
+
+from .models import UpdateHistoryEntry
+
+log = logging.getLogger("rapidboxes.update_history")
+
+# A rolling "recent versions" log, not a full audit trail -- cap growth so it
+# never becomes a maintenance concern on a box that's been auto-updating
+# monthly for years.
+MAX_ENTRIES = 50
+
+
+def load_history(path: Path) -> List[UpdateHistoryEntry]:
+    if not path.exists():
+        return []
+    try:
+        raw = json.loads(path.read_text())
+        return [UpdateHistoryEntry.model_validate(item) for item in raw]
+    except Exception:
+        log.exception("invalid update history file %s; treating as empty", path)
+        return []
+
+
+def save_history(path: Path, entries: List[UpdateHistoryEntry]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    payload = json.dumps([e.model_dump(mode="json") for e in entries[-MAX_ENTRIES:]], indent=2)
+    tmp.write_text(payload)
+    os.replace(tmp, path)
+
+
+def append_entry(path: Path, entry: UpdateHistoryEntry) -> UpdateHistoryEntry:
+    entries = load_history(path)
+    entries.append(entry)
+    save_history(path, entries)
+    return entry

--- a/back/rapidboxes/updater.py
+++ b/back/rapidboxes/updater.py
@@ -18,16 +18,23 @@ Safety:
 - An update is refused outright (no fetch/merge attempted) while an
   experiment is running/paused/finishing -- see `BUSY_EXPERIMENT_STATES`,
   the in-process check in `api/update.py`, and `check_experiment_active_via_http`
-  for the CLI's out-of-process equivalent.
+  for the CLI's out-of-process equivalent. The same gate applies to
+  `rollback_update()`.
+- Rollback moves the working tree with `git checkout --detach <commit>`,
+  never `git reset --hard` on the branch ref -- see `rollback_update` for
+  why.
 """
 from __future__ import annotations
 
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-from .models import ExperimentState, UpdateApplyResult, UpdateCheckResult
+from .config import get_config
+from .models import ExperimentState, UpdateApplyResult, UpdateCheckResult, UpdateHistoryEntry, VersionStatus
+from .update_history import append_entry, load_history
 
 # Experiment states that make an update unsafe to apply -- mirrors the
 # "busy" check in engine/runner.py's own start() guard.
@@ -88,6 +95,22 @@ def get_repo_root() -> Path:
     root = _run_git(["rev-parse", "--show-toplevel"], here).strip()
     _repo_root_cache = Path(root)
     return _repo_root_cache
+
+
+def _commit_datetime(commit: str, repo: Path) -> datetime:
+    """Best-effort "when was this commit made", for seeding history entries.
+
+    Used only when the history file has no entries yet (fresh install, or a
+    box that predates this feature) -- we don't actually know when the
+    current checkout was installed, so the commit's own commit-date is a much
+    better proxy for "how long has this been running" than `now()`, which
+    would make a freshly-seeded box always report ~0 uptime.
+    """
+    try:
+        raw = _run_git(["show", "-s", "--format=%cI", commit], repo).strip()
+        return datetime.fromisoformat(raw)
+    except Exception:
+        return datetime.now(timezone.utc)
 
 
 # ---------------------------------------------------------------------------
@@ -230,7 +253,12 @@ def check_for_update(branch: str, repo_root: Optional[Path] = None) -> UpdateChe
         return UpdateCheckResult(branch=branch, updateAvailable=False, error=str(e))
 
 
-def apply_update(branch: str, repo_root: Optional[Path] = None) -> UpdateApplyResult:
+def apply_update(
+    branch: str,
+    repo_root: Optional[Path] = None,
+    history_path: Optional[Path] = None,
+    trigger: str = "manual",
+) -> UpdateApplyResult:
     """`git fetch origin <branch>` then `git merge --ff-only origin/<branch>`.
 
     Refuses (returns status="error", changes nothing) if the working tree has
@@ -242,18 +270,23 @@ def apply_update(branch: str, repo_root: Optional[Path] = None) -> UpdateApplyRe
     frontend build) actually changed -- see `_rebuild_after_pull` -- and
     reports that separately via rebuildStatus/rebuildMessage, since a pull
     that succeeded but whose rebuild failed leaves the process on mismatched
-    code and deps, a worse state than a clean refusal.
+    code and deps, a worse state than a clean refusal. Also appends a
+    version-history entry (see update_history.py) recording the new commit,
+    when, and `trigger` ("manual" from the Settings button, "monthly" from
+    the CLI/timer) -- this is what powers the "running commit X for Y" /
+    rollback UI.
 
     Does NOT check whether an experiment is active -- callers (the API
     endpoint / the CLI's `main()`) must gate on that themselves first, since
     only they know how to observe live state (in-process vs. over loopback
     HTTP). See `check_experiment_active_via_http` for the CLI's version.
 
-    `repo_root` defaults to the real repo (autodetected via `git rev-parse
-    --show-toplevel`); tests pass a throwaway repo instead.
+    `repo_root` / `history_path` default to the real repo / configured
+    history file; tests pass throwaway paths instead.
     """
     try:
         repo = repo_root or get_repo_root()
+        hpath = history_path or get_config().update_history_path
         _run_git(["fetch", "origin", branch], repo)
 
         dirty = _run_git(["status", "--porcelain"], repo).strip()
@@ -289,9 +322,158 @@ def apply_update(branch: str, repo_root: Optional[Path] = None) -> UpdateApplyRe
 
         rebuild_status, rebuild_message = _rebuild_after_pull(before, after, repo)
 
+        append_entry(
+            hpath,
+            UpdateHistoryEntry(commit=after[:8], appliedAt=datetime.now(timezone.utc), trigger=trigger),
+        )
+
         return UpdateApplyResult(
             status="updated",
             message=f"Updated {before[:8]} -> {after[:8]}.",
+            fromCommit=before[:8],
+            toCommit=after[:8],
+            rebuildStatus=rebuild_status,
+            rebuildMessage=rebuild_message,
+        )
+    except UpdaterError as e:
+        return UpdateApplyResult(status="error", message=str(e))
+
+
+def get_version_status(history_path: Path, repo_root: Optional[Path] = None) -> VersionStatus:
+    """What's currently running, and (if any) what it can roll back to.
+
+    Lazily seeds `history_path` with a single "seed" entry for the current
+    HEAD if it has no entries yet -- a box that's never run an OTA update (or
+    is still on the very first install.sh checkout) has no prior entries, but
+    "how long has the current version been running" should still have an
+    answer. See `_commit_datetime` for why the seed's timestamp is the
+    commit's own date rather than "now".
+
+    Trusts the history file as the record of truth for what's "current" --
+    it does not reconcile against live git HEAD beyond the initial seed, so
+    an update applied outside this module (e.g. a manual `deploy/update.sh`
+    pull) won't be reflected here until the next apply/rollback through it.
+    """
+    try:
+        repo = repo_root or get_repo_root()
+        history = load_history(history_path)
+        if not history:
+            head = _run_git(["rev-parse", "HEAD"], repo).strip()
+            seeded = append_entry(
+                history_path,
+                UpdateHistoryEntry(commit=head[:8], appliedAt=_commit_datetime(head, repo), trigger="seed"),
+            )
+            history = [seeded]
+
+        current = history[-1]
+        previous = history[-2] if len(history) >= 2 else None
+        return VersionStatus(current=current, previous=previous)
+    except UpdaterError as e:
+        return VersionStatus(error=str(e))
+
+
+def rollback_update(history_path: Path, repo_root: Optional[Path] = None) -> UpdateApplyResult:
+    """Move the working tree back to the previous recorded commit.
+
+    Judgment call: this uses `git checkout --detach <commit>`, not
+    `git reset --hard <commit>` on the tracked branch. Weighed both:
+
+    - `reset --hard` would rewrite the branch ref (e.g. refs/heads/main)
+      itself backward. That's a bigger hammer than needed here, and it has a
+      nasty side effect: the *next* `apply_update()` (or the monthly timer)
+      fetches, compares local HEAD to origin/<branch>, and sees it's simply
+      "behind" by the exact commits we just rolled back through --
+      `merge --ff-only` would then happily fast-forward right back onto the
+      commit we were trying to get away from, silently undoing the rollback
+      on the very next check.
+    - `checkout --detach` instead moves only the *working tree* + HEAD to
+      that commit, leaving HEAD detached (not pointing at refs/heads/<branch>
+      at all). refs/heads/<branch> is untouched. A subsequent apply_update()
+      still fetches fine, but `git merge --ff-only origin/<branch>` from a
+      detached HEAD that isn't a fast-forward ancestor of origin/<branch>
+      fails correctly instead of silently reapplying the rolled-back commit
+      -- i.e. it fails the same safe way a diverged-history apply already
+      does. (Still worth flagging to the user: see the "risk" note surfaced
+      by the UI -- a human explicitly re-running "Update Now" after a
+      rollback, or the next monthly run once history has "moved on" past the
+      rolled-back commit, can still land back on it. This module doesn't try
+      to prevent that; it only avoids doing it *silently* on the very next
+      routine check.)
+
+    Refuses (no-op) if the working tree is dirty, or if there's no previous
+    entry recorded to roll back to. Does NOT check whether an experiment is
+    active -- same split of responsibility as apply_update(): callers gate
+    on that first.
+
+    Unlike apply_update(), this needs no network access -- the rollback
+    target is a commit this repo already has (it was HEAD before), so no
+    `git fetch` is required.
+    """
+    try:
+        repo = repo_root or get_repo_root()
+        history = load_history(history_path)
+
+        if not history:
+            # Mirror get_version_status()'s lazy seed so a box that calls
+            # rollback before ever calling check/apply/version still gets a
+            # sensible history file going forward -- but there is still
+            # nothing *previous* to offer.
+            head = _run_git(["rev-parse", "HEAD"], repo).strip()
+            append_entry(
+                history_path,
+                UpdateHistoryEntry(commit=head[:8], appliedAt=_commit_datetime(head, repo), trigger="seed"),
+            )
+            return UpdateApplyResult(
+                status="nothing_to_roll_back_to", message="No previous version recorded yet."
+            )
+
+        if len(history) < 2:
+            return UpdateApplyResult(
+                status="nothing_to_roll_back_to", message="No previous version recorded yet."
+            )
+
+        target_entry = history[-2]
+
+        dirty = _run_git(["status", "--porcelain"], repo).strip()
+        if dirty:
+            return UpdateApplyResult(
+                status="error",
+                message=(
+                    "Working tree has local changes; refusing to roll back. "
+                    "Resolve manually before retrying."
+                ),
+            )
+
+        before = _run_git(["rev-parse", "HEAD"], repo).strip()
+
+        try:
+            target_full = _run_git(["rev-parse", target_entry.commit], repo).strip()
+        except UpdaterError:
+            return UpdateApplyResult(
+                status="error",
+                message=(
+                    f"Recorded previous commit {target_entry.commit} no longer exists in "
+                    "this repo (it may have been garbage-collected)."
+                ),
+            )
+
+        try:
+            _run_git(["checkout", "--detach", target_full], repo)
+        except UpdaterError as e:
+            return UpdateApplyResult(status="error", message=f"Rollback checkout failed: {e}")
+
+        after = _run_git(["rev-parse", "HEAD"], repo).strip()
+
+        rebuild_status, rebuild_message = _rebuild_after_pull(before, after, repo)
+
+        append_entry(
+            history_path,
+            UpdateHistoryEntry(commit=after[:8], appliedAt=datetime.now(timezone.utc), trigger="rollback"),
+        )
+
+        return UpdateApplyResult(
+            status="rolled_back",
+            message=f"Rolled back {before[:8]} -> {after[:8]}.",
             fromCommit=before[:8],
             toCommit=after[:8],
             rebuildStatus=rebuild_status,
@@ -354,8 +536,6 @@ def main(argv: Optional[List[str]] = None) -> int:
     import argparse
     import sys
 
-    from .config import get_config
-
     parser = argparse.ArgumentParser(
         description="RaPiD-boxes OTA updater (git fetch + fast-forward-only pull)."
     )
@@ -390,7 +570,9 @@ def main(argv: Optional[List[str]] = None) -> int:
         print(result.message, file=sys.stderr)
         return 1
 
-    result = apply_update(config.update_branch)
+    result = apply_update(
+        config.update_branch, history_path=config.update_history_path, trigger="monthly"
+    )
     print(result.model_dump_json())
 
     if result.status == "updated" and args.restart_on_success:

--- a/back/tests/test_api.py
+++ b/back/tests/test_api.py
@@ -56,6 +56,15 @@ async def test_system_info(client: AsyncClient):
     assert "diskFreeBytes" in body
     assert body["cameraAvailable"] is True
 
+    # SSH info card (Settings -> General): sshUser should resolve to the
+    # real OS account running the tests on any POSIX box (dev laptop or CI),
+    # via pwd.getpwuid -- never blank. sshEnabled's actual value is
+    # environment-dependent (no systemd on most dev laptops), so only check
+    # its shape, not a specific value.
+    assert isinstance(body["sshUser"], str)
+    assert body["sshUser"] != ""
+    assert isinstance(body["sshEnabled"], bool)
+
 
 @pytest.mark.asyncio
 async def test_update_check_endpoint_delegates_to_updater(client: AsyncClient, monkeypatch):

--- a/back/tests/test_api.py
+++ b/back/tests/test_api.py
@@ -1,6 +1,7 @@
 """FastAPI integration tests with simulated hardware."""
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -8,7 +9,14 @@ from httpx import ASGITransport, AsyncClient
 
 from rapidboxes.config import AppConfig
 from rapidboxes.main import create_app
-from rapidboxes.models import ExperimentState, TropismConfig, UpdateApplyResult, UpdateCheckResult
+from rapidboxes.models import (
+    ExperimentState,
+    TropismConfig,
+    UpdateApplyResult,
+    UpdateCheckResult,
+    UpdateHistoryEntry,
+    VersionStatus,
+)
 
 
 @pytest.fixture
@@ -74,7 +82,7 @@ async def test_update_check_endpoint_delegates_to_updater(client: AsyncClient, m
 
 @pytest.mark.asyncio
 async def test_update_apply_endpoint_delegates_to_updater(client: AsyncClient, monkeypatch):
-    def fake_apply(branch, repo_root=None):
+    def fake_apply(branch, repo_root=None, **kwargs):
         return UpdateApplyResult(status="updated", message="ok", fromCommit="aaa", toCommit="bbb")
 
     monkeypatch.setattr("rapidboxes.api.update.apply_update", fake_apply)
@@ -96,7 +104,7 @@ async def test_update_apply_refused_while_experiment_busy(
     # sets runner.status.state directly rather than driving it via HTTP.
     called = {"n": 0}
 
-    def fake_apply(branch, repo_root=None):
+    def fake_apply(branch, repo_root=None, **kwargs):
         called["n"] += 1
         return UpdateApplyResult(status="updated", message="should not have been called")
 
@@ -120,7 +128,7 @@ async def test_update_apply_refused_while_experiment_busy(
 async def test_update_apply_allowed_while_experiment_not_active(
     app_config: AppConfig, monkeypatch, state_value: str
 ):
-    def fake_apply(branch, repo_root=None):
+    def fake_apply(branch, repo_root=None, **kwargs):
         return UpdateApplyResult(status="up_to_date", message="already current")
 
     monkeypatch.setattr("rapidboxes.api.update.apply_update", fake_apply)
@@ -153,6 +161,81 @@ async def test_update_check_allowed_even_while_experiment_running(
             res = await ac.get("/api/system/update/check")
             assert res.status_code == 200
             assert res.json()["updateAvailable"] is True
+
+
+@pytest.mark.asyncio
+async def test_update_version_endpoint_delegates_to_updater(client: AsyncClient, monkeypatch):
+    entry = UpdateHistoryEntry(commit="abc12345", appliedAt=datetime.now(timezone.utc), trigger="manual")
+
+    def fake_version(history_path):
+        return VersionStatus(current=entry, previous=None)
+
+    monkeypatch.setattr("rapidboxes.api.update.get_version_status", fake_version)
+
+    res = await client.get("/api/system/update/version")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["current"]["commit"] == "abc12345"
+    assert body["previous"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_rollback_endpoint_delegates_to_updater(client: AsyncClient, monkeypatch):
+    def fake_rollback(history_path):
+        return UpdateApplyResult(status="rolled_back", message="ok", fromCommit="bbb", toCommit="aaa")
+
+    monkeypatch.setattr("rapidboxes.api.update.rollback_update", fake_rollback)
+
+    res = await client.post("/api/system/update/rollback")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["status"] == "rolled_back"
+    assert body["toCommit"] == "aaa"
+
+
+@pytest.mark.parametrize("state_value", ["running", "paused", "finishing"])
+@pytest.mark.asyncio
+async def test_update_rollback_refused_while_experiment_busy(
+    app_config: AppConfig, monkeypatch, state_value: str
+):
+    called = {"n": 0}
+
+    def fake_rollback(history_path):
+        called["n"] += 1
+        return UpdateApplyResult(status="rolled_back", message="should not have been called")
+
+    monkeypatch.setattr("rapidboxes.api.update.rollback_update", fake_rollback)
+
+    app = create_app(app_config)
+    async with app.router.lifespan_context(app):
+        app.state.app.runner.status.state = ExperimentState(state_value)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            res = await ac.post("/api/system/update/rollback")
+            assert res.status_code == 200
+            assert res.json()["status"] == "experiment_active"
+
+    assert called["n"] == 0
+
+
+@pytest.mark.parametrize("state_value", ["idle", "done", "error"])
+@pytest.mark.asyncio
+async def test_update_rollback_allowed_while_experiment_not_active(
+    app_config: AppConfig, monkeypatch, state_value: str
+):
+    def fake_rollback(history_path):
+        return UpdateApplyResult(status="nothing_to_roll_back_to", message="No previous version recorded yet.")
+
+    monkeypatch.setattr("rapidboxes.api.update.rollback_update", fake_rollback)
+
+    app = create_app(app_config)
+    async with app.router.lifespan_context(app):
+        app.state.app.runner.status.state = ExperimentState(state_value)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            res = await ac.post("/api/system/update/rollback")
+            assert res.status_code == 200
+            assert res.json()["status"] == "nothing_to_roll_back_to"
 
 
 @pytest.mark.asyncio

--- a/back/tests/test_updater.py
+++ b/back/tests/test_updater.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 import pytest
 
-from rapidboxes.updater import apply_update, check_for_update
+from rapidboxes.update_history import load_history
+from rapidboxes.updater import apply_update, check_for_update, get_version_status, rollback_update
 
 
 def _git(args, cwd: Path) -> str:
@@ -215,6 +216,170 @@ def test_apply_reports_rebuild_failure_distinctly_without_reverting_the_pull(
 
 
 # ---------------------------------------------------------------------------
+# Version history + rollback. `history_path` is always an explicit tmp_path
+# file here (never the real config default) so these tests can never touch a
+# developer's actual ~/rapidboxes/update_history.json.
+# ---------------------------------------------------------------------------
+
+
+def test_apply_records_history_entry_on_success(remote_and_local, tmp_path):
+    remote, local = remote_and_local
+    remote_head = _commit(remote, "b.txt", "2", "second commit")
+    history_path = tmp_path / "history.json"
+
+    result = apply_update("main", repo_root=local, history_path=history_path)
+    assert result.status == "updated"
+
+    entries = load_history(history_path)
+    assert len(entries) == 1
+    assert entries[0].commit == remote_head[:8]
+    assert entries[0].trigger == "manual"  # default trigger
+
+
+def test_apply_records_the_trigger_it_was_given(remote_and_local, tmp_path):
+    remote, local = remote_and_local
+    _commit(remote, "b.txt", "2", "second commit")
+    history_path = tmp_path / "history.json"
+
+    result = apply_update("main", repo_root=local, history_path=history_path, trigger="monthly")
+    assert result.status == "updated"
+    assert load_history(history_path)[-1].trigger == "monthly"
+
+
+def test_apply_does_not_record_history_when_already_up_to_date(remote_and_local, tmp_path):
+    _remote, local = remote_and_local
+    history_path = tmp_path / "history.json"
+
+    result = apply_update("main", repo_root=local, history_path=history_path)
+    assert result.status == "up_to_date"
+    assert load_history(history_path) == []
+
+
+def test_version_status_seeds_when_no_history_exists_yet(remote_and_local, tmp_path):
+    _remote, local = remote_and_local
+    history_path = tmp_path / "history.json"
+    assert not history_path.exists()
+
+    status = get_version_status(history_path, repo_root=local)
+    assert status.error is None
+    assert status.current is not None
+    head = _git(["rev-parse", "HEAD"], local).strip()
+    assert status.current.commit == head[:8]
+    assert status.current.trigger == "seed"
+    assert status.previous is None
+
+    # Persisted, not just returned in-memory -- the next call (or the
+    # rollback path) sees the same seeded entry rather than re-seeding.
+    assert history_path.exists()
+    assert len(load_history(history_path)) == 1
+
+
+def test_version_status_reports_current_and_previous_after_two_applies(remote_and_local, tmp_path):
+    remote, local = remote_and_local
+    history_path = tmp_path / "history.json"
+
+    first_head = _commit(remote, "b.txt", "2", "first update")
+    apply_update("main", repo_root=local, history_path=history_path)
+
+    second_head = _commit(remote, "c.txt", "3", "second update")
+    apply_update("main", repo_root=local, history_path=history_path)
+
+    status = get_version_status(history_path, repo_root=local)
+    assert status.current.commit == second_head[:8]
+    assert status.previous is not None
+    assert status.previous.commit == first_head[:8]
+
+
+def test_rollback_moves_head_back_and_history_carries_a_computable_duration(
+    remote_and_local, tmp_path
+):
+    remote, local = remote_and_local
+    history_path = tmp_path / "history.json"
+
+    first_head = _commit(remote, "b.txt", "2", "first update")
+    apply_update("main", repo_root=local, history_path=history_path)
+    first_entry_time = load_history(history_path)[-1].appliedAt
+
+    second_head = _commit(remote, "c.txt", "3", "second update")
+    apply_update("main", repo_root=local, history_path=history_path)
+    second_entry_time = load_history(history_path)[-1].appliedAt
+
+    # Real, distinct timestamps -- a "ran for" duration downstream (UI
+    # subtracts these) is only meaningful if they actually differ.
+    assert first_entry_time < second_entry_time
+
+    result = rollback_update(history_path, repo_root=local)
+    assert result.status == "rolled_back"
+    assert result.toCommit == first_head[:8]
+
+    head = _git(["rev-parse", "HEAD"], local).strip()
+    assert head == first_head
+    assert (local / "b.txt").exists()
+    assert not (local / "c.txt").exists()
+    # Rollback moves the working tree via `checkout --detach`, not
+    # `reset --hard` on the branch -- refs/heads/main is untouched.
+    branch_tip = _git(["rev-parse", "refs/heads/main"], local).strip()
+    assert branch_tip == second_head
+
+    entries = load_history(history_path)
+    assert len(entries) == 3
+    assert entries[-1].commit == first_head[:8]
+    assert entries[-1].trigger == "rollback"
+
+    # get_version_status() now reports the rolled-back-to commit as current
+    # and the just-abandoned one as previous, with the original timestamp
+    # preserved -- so the UI can compute "ran for X" for the abandoned
+    # version from real data, not a guess.
+    status = get_version_status(history_path, repo_root=local)
+    assert status.current.commit == first_head[:8]
+    assert status.previous.commit == second_head[:8]
+    assert status.previous.appliedAt == second_entry_time
+
+
+def test_rollback_refuses_on_dirty_tree(remote_and_local, tmp_path):
+    remote, local = remote_and_local
+    history_path = tmp_path / "history.json"
+
+    _commit(remote, "b.txt", "2", "first update")
+    apply_update("main", repo_root=local, history_path=history_path)
+    _commit(remote, "c.txt", "3", "second update")
+    apply_update("main", repo_root=local, history_path=history_path)
+
+    (local / "b.txt").write_text("dirty, uncommitted")
+
+    result = rollback_update(history_path, repo_root=local)
+    assert result.status == "error"
+    assert "local changes" in result.message
+
+    # Nothing moved -- still on the second commit, dirty file untouched.
+    head = _git(["rev-parse", "HEAD"], local).strip()
+    assert (local / "c.txt").exists()
+    assert (local / "b.txt").read_text() == "dirty, uncommitted"
+
+
+def test_rollback_with_no_history_returns_nothing_to_roll_back_to(remote_and_local, tmp_path):
+    _remote, local = remote_and_local
+    history_path = tmp_path / "history.json"
+    assert not history_path.exists()
+
+    result = rollback_update(history_path, repo_root=local)
+    assert result.status == "nothing_to_roll_back_to"
+    assert "no previous version" in result.message.lower()
+
+
+def test_rollback_with_only_one_history_entry_returns_nothing_to_roll_back_to(
+    remote_and_local, tmp_path
+):
+    remote, local = remote_and_local
+    history_path = tmp_path / "history.json"
+    _commit(remote, "b.txt", "2", "first update")
+    apply_update("main", repo_root=local, history_path=history_path)
+
+    result = rollback_update(history_path, repo_root=local)
+    assert result.status == "nothing_to_roll_back_to"
+
+
+# ---------------------------------------------------------------------------
 # CLI: experiment-active gate + restart-on-rebuild-failure behaviour.
 # apply_update() itself is faked here (already covered above / by the
 # fast-forward tests) so these focus purely on main()'s control flow.
@@ -241,7 +406,7 @@ def test_cli_apply_refuses_when_experiment_active(monkeypatch, capsys, cli_confi
     monkeypatch.setattr(updater, "check_experiment_active_via_http", lambda port, timeout=5.0: True)
     called = {"n": 0}
 
-    def fake_apply(branch, repo_root=None):
+    def fake_apply(branch, repo_root=None, **kwargs):
         called["n"] += 1
         return updater.UpdateApplyResult(status="updated", message="should not run")
 
@@ -258,7 +423,7 @@ def test_cli_apply_proceeds_when_experiment_not_active(monkeypatch, capsys, cli_
 
     monkeypatch.setattr(updater, "check_experiment_active_via_http", lambda port, timeout=5.0: False)
 
-    def fake_apply(branch, repo_root=None):
+    def fake_apply(branch, repo_root=None, **kwargs):
         return updater.UpdateApplyResult(status="up_to_date", message="already current")
 
     monkeypatch.setattr(updater, "apply_update", fake_apply)
@@ -273,7 +438,7 @@ def test_cli_triggers_restart_after_successful_pull_and_rebuild(monkeypatch, cli
 
     monkeypatch.setattr(updater, "check_experiment_active_via_http", lambda port, timeout=5.0: False)
 
-    def fake_apply(branch, repo_root=None):
+    def fake_apply(branch, repo_root=None, **kwargs):
         return updater.UpdateApplyResult(
             status="updated", message="ok", fromCommit="a", toCommit="b",
             rebuildStatus="ok", rebuildMessage="rebuilt",
@@ -293,7 +458,7 @@ def test_cli_does_not_restart_when_rebuild_failed(monkeypatch, capsys, cli_confi
 
     monkeypatch.setattr(updater, "check_experiment_active_via_http", lambda port, timeout=5.0: False)
 
-    def fake_apply(branch, repo_root=None):
+    def fake_apply(branch, repo_root=None, **kwargs):
         return updater.UpdateApplyResult(
             status="updated", message="ok", fromCommit="a", toCommit="b",
             rebuildStatus="failed", rebuildMessage="npm blew up",

--- a/front/plant-imaging-controller-faa-main/client/components/GeneralSettingsMenu.tsx
+++ b/front/plant-imaging-controller-faa-main/client/components/GeneralSettingsMenu.tsx
@@ -1,3 +1,5 @@
+import { Copy } from "lucide-react";
+import { toast } from "sonner";
 import { useSystemInfo } from "@/hooks/useSystemInfo";
 import UpdatePanel from "@/components/UpdatePanel";
 
@@ -18,6 +20,18 @@ export default function GeneralSettingsMenu() {
       ? Math.round(((system.diskTotalBytes - system.diskFreeBytes) / system.diskTotalBytes) * 100)
       : 0;
 
+  const sshCommand = system?.sshUser && system?.ip ? `ssh ${system.sshUser}@${system.ip}` : null;
+
+  const handleCopySsh = async () => {
+    if (!sshCommand) return;
+    try {
+      await navigator.clipboard.writeText(sshCommand);
+      toast.success("SSH command copied");
+    } catch {
+      toast.error("Could not copy — select the text and copy it manually");
+    }
+  };
+
   return (
     <div className="flex h-full flex-col">
       <div className="flex-1 overflow-y-auto p-2">
@@ -35,6 +49,8 @@ export default function GeneralSettingsMenu() {
               <dd className="font-semibold text-white">
                 {system?.simulation ? "Simulation" : "Hardware"}
               </dd>
+              <dt className="text-app-text-muted">IP Address</dt>
+              <dd className="truncate font-semibold text-white">{system?.ip ?? "—"}</dd>
               <dt className="text-app-text-muted">Storage</dt>
               <dd className="truncate font-semibold text-white" title={system?.storageRoot}>
                 {system?.storageRoot ?? "—"}
@@ -79,6 +95,46 @@ export default function GeneralSettingsMenu() {
               <p className="mt-2 text-[10px] font-semibold text-app-orange-light">
                 Less than 2 GB free — consider exporting or removing old experiments.
               </p>
+            )}
+          </div>
+
+          <div className="rounded-[10px] border border-app-border-primary bg-app-bg-secondary p-3">
+            <div className="text-[10px] font-bold uppercase tracking-[0.5px] text-app-text-muted">
+              SSH Access
+            </div>
+            <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1.5 text-[11px]">
+              <dt className="text-app-text-muted">Status</dt>
+              <dd
+                className={`font-semibold ${
+                  system == null
+                    ? "text-white"
+                    : system.sshEnabled
+                      ? "text-app-green"
+                      : "text-app-orange"
+                }`}
+              >
+                {system == null ? "—" : system.sshEnabled ? "Enabled" : "Disabled"}
+              </dd>
+              <dt className="text-app-text-muted">User</dt>
+              <dd className="truncate font-semibold text-white">{system?.sshUser || "—"}</dd>
+            </dl>
+            {sshCommand ? (
+              <button
+                onClick={handleCopySsh}
+                title="Tap to copy"
+                className="mt-2 flex w-full items-center justify-between gap-2 rounded-md bg-app-bg-tertiary px-3 py-2 transition-colors hover:bg-app-border-primary"
+              >
+                <span className="truncate font-mono text-[12px] text-white">{sshCommand}</span>
+                <Copy className="h-[14px] w-[14px] flex-shrink-0 text-app-text-secondary" strokeWidth={1.75} />
+              </button>
+            ) : (
+              system && (
+                <p className="mt-2 text-[10px] text-app-text-muted">
+                  {system.sshEnabled
+                    ? "Waiting for network info…"
+                    : "SSH is disabled on this device."}
+                </p>
+              )
             )}
           </div>
 

--- a/front/plant-imaging-controller-faa-main/client/components/UpdatePanel.tsx
+++ b/front/plant-imaging-controller-faa-main/client/components/UpdatePanel.tsx
@@ -1,24 +1,72 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { restartAppToHome } from "@/lib/restartApp";
-import type { UpdateCheckResult } from "@shared/api";
+import type { UpdateCheckResult, VersionStatus } from "@shared/api";
 
 /**
- * OTA self-update card for Settings -> General. Two-step, both explicit:
- * "Check for Updates" only fetches + compares (never touches the working
- * tree); "Update Now" does the fast-forward-only pull. The same monthly
- * unattended check (deploy/rapidboxes-update.timer) runs the identical git
- * logic headlessly and restarts automatically on success -- here a human is
- * present, so we ask before restarting instead.
+ * OTA self-update card for Settings -> General. Two independent flows:
+ *  - "Software Update": "Check for Updates" only fetches + compares (never
+ *    touches the working tree); "Update Now" does the fast-forward-only
+ *    pull. The same monthly unattended check (deploy/rapidboxes-update.timer)
+ *    runs the identical git logic headlessly and restarts automatically on
+ *    success -- here a human is present, so we ask before restarting instead.
+ *  - "Version": shows the currently-running commit + how long it's been
+ *    running, and (once a previous version is on record) a "Roll back"
+ *    button. Both flows end at the same restart-prompt overlay on success.
  */
-type Phase = "idle" | "checking" | "available" | "applying" | "restart-prompt";
+type Phase = "idle" | "checking" | "available" | "applying";
+
+function formatDuration(ms: number): string {
+  const totalMinutes = Math.floor(Math.max(0, ms) / 60000);
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m`;
+  return "just now";
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
 
 export default function UpdatePanel() {
+  // "Check for updates" / "Update Now" flow.
   const [phase, setPhase] = useState<Phase>("idle");
   const [check, setCheck] = useState<UpdateCheckResult | null>(null);
+
+  // "Version" / rollback flow -- independent of the above.
+  const [version, setVersion] = useState<VersionStatus | null>(null);
+  const [versionLoading, setVersionLoading] = useState(true);
+  const [rollbackConfirming, setRollbackConfirming] = useState(false);
+  const [rollingBack, setRollingBack] = useState(false);
+
+  // Shared: both flows end here on a successful, rebuild-clean git move.
+  const [restartPromptVisible, setRestartPromptVisible] = useState(false);
   const [restarting, setRestarting] = useState(false);
+
+  const refreshVersion = async () => {
+    try {
+      const v = await api.versionStatus();
+      setVersion(v);
+    } catch {
+      // best-effort -- leave whatever we last had (or null on first load)
+    } finally {
+      setVersionLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refreshVersion();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleCheck = async () => {
     if (phase === "checking" || phase === "applying") return;
@@ -60,6 +108,7 @@ export default function UpdatePanel() {
         return;
       }
       // status === "updated"
+      await refreshVersion();
       if (result.rebuildStatus === "failed") {
         // The git pull succeeded but the dependency/build step didn't --
         // code and installed deps are now mismatched. Don't offer to
@@ -74,7 +123,9 @@ export default function UpdatePanel() {
         setPhase("idle");
         return;
       }
-      setPhase("restart-prompt");
+      setCheck(null);
+      setPhase("idle");
+      setRestartPromptVisible(true);
     } catch (e) {
       toast.error(`Update failed: ${(e as Error).message}`);
       setPhase("available");
@@ -86,61 +137,168 @@ export default function UpdatePanel() {
     setPhase("idle");
   };
 
+  const handleRollback = async () => {
+    setRollingBack(true);
+    try {
+      const result = await api.rollbackUpdate();
+      if (result.status === "error" || result.status === "experiment_active") {
+        toast.error(result.message);
+        return;
+      }
+      if (result.status === "nothing_to_roll_back_to") {
+        toast.error(result.message);
+        await refreshVersion();
+        return;
+      }
+      // status === "rolled_back"
+      await refreshVersion();
+      if (result.rebuildStatus === "failed") {
+        toast.error(
+          `Rollback moved the code back but the rebuild failed: ${
+            result.rebuildMessage ?? "unknown error"
+          }. Do not restart until this is resolved manually.`,
+          { duration: 15000 },
+        );
+        return;
+      }
+      setRestartPromptVisible(true);
+    } catch (e) {
+      toast.error(`Rollback failed: ${(e as Error).message}`);
+    } finally {
+      setRollingBack(false);
+      setRollbackConfirming(false);
+    }
+  };
+
+  const currentRunningFor = version?.current
+    ? formatDuration(Date.now() - new Date(version.current.appliedAt).getTime())
+    : null;
+  const previousRanFor =
+    version?.current && version?.previous
+      ? formatDuration(
+          new Date(version.current.appliedAt).getTime() - new Date(version.previous.appliedAt).getTime(),
+        )
+      : null;
+
   return (
-    <div className="rounded-[10px] border border-app-border-primary bg-app-bg-secondary p-3">
-      <div className="text-[10px] font-bold uppercase tracking-[0.5px] text-app-text-muted">
-        Software Update
+    <>
+      <div className="rounded-[10px] border border-app-border-primary bg-app-bg-secondary p-3">
+        <div className="text-[10px] font-bold uppercase tracking-[0.5px] text-app-text-muted">
+          Software Update
+        </div>
+
+        {phase !== "available" && phase !== "applying" && (
+          <button
+            onClick={handleCheck}
+            disabled={phase === "checking"}
+            className="mt-2 flex w-full items-center justify-center gap-2 rounded-md bg-app-bg-tertiary py-2 text-[12px] font-semibold text-white transition-colors hover:bg-app-border-primary disabled:opacity-60"
+          >
+            <RefreshCw
+              className={`h-[14px] w-[14px] ${phase === "checking" ? "animate-spin" : ""}`}
+              strokeWidth={1.75}
+            />
+            {phase === "checking" ? "Checking…" : "Check for Updates"}
+          </button>
+        )}
+
+        {(phase === "available" || phase === "applying") && check && (
+          <div className="mt-2 rounded-md border border-app-green/40 bg-app-green/10 p-2.5">
+            <p className="text-[11px] font-semibold text-white">
+              {check.commitsBehind} commit{check.commitsBehind === 1 ? "" : "s"} behind{" "}
+              origin/{check.branch}
+            </p>
+            {check.commitLog.length > 0 && (
+              <ul className="mt-1.5 max-h-24 space-y-0.5 overflow-y-auto text-[10px] text-app-text-muted">
+                {check.commitLog.map((line, i) => (
+                  <li key={i} className="truncate">
+                    {line}
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div className="mt-2 flex gap-2">
+              <button
+                onClick={handleApply}
+                disabled={phase === "applying"}
+                className="flex-1 rounded-md bg-app-green py-1.5 text-[11px] font-bold uppercase tracking-wide text-white transition-opacity hover:opacity-90 disabled:opacity-60"
+              >
+                {phase === "applying" ? "Updating…" : "Update Now"}
+              </button>
+              <button
+                onClick={dismiss}
+                disabled={phase === "applying"}
+                className="flex-1 rounded-md bg-app-bg-tertiary py-1.5 text-[11px] font-semibold text-app-text-secondary transition-colors hover:bg-app-border-primary disabled:opacity-60"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        )}
       </div>
 
-      {phase !== "available" && phase !== "applying" && (
-        <button
-          onClick={handleCheck}
-          disabled={phase === "checking"}
-          className="mt-2 flex w-full items-center justify-center gap-2 rounded-md bg-app-bg-tertiary py-2 text-[12px] font-semibold text-white transition-colors hover:bg-app-border-primary disabled:opacity-60"
-        >
-          <RefreshCw
-            className={`h-[14px] w-[14px] ${phase === "checking" ? "animate-spin" : ""}`}
-            strokeWidth={1.75}
-          />
-          {phase === "checking" ? "Checking…" : "Check for Updates"}
-        </button>
-      )}
-
-      {(phase === "available" || phase === "applying") && check && (
-        <div className="mt-2 rounded-md border border-app-green/40 bg-app-green/10 p-2.5">
-          <p className="text-[11px] font-semibold text-white">
-            {check.commitsBehind} commit{check.commitsBehind === 1 ? "" : "s"} behind{" "}
-            origin/{check.branch}
-          </p>
-          {check.commitLog.length > 0 && (
-            <ul className="mt-1.5 max-h-24 space-y-0.5 overflow-y-auto text-[10px] text-app-text-muted">
-              {check.commitLog.map((line, i) => (
-                <li key={i} className="truncate">
-                  {line}
-                </li>
-              ))}
-            </ul>
-          )}
-          <div className="mt-2 flex gap-2">
-            <button
-              onClick={handleApply}
-              disabled={phase === "applying"}
-              className="flex-1 rounded-md bg-app-green py-1.5 text-[11px] font-bold uppercase tracking-wide text-white transition-opacity hover:opacity-90 disabled:opacity-60"
-            >
-              {phase === "applying" ? "Updating…" : "Update Now"}
-            </button>
-            <button
-              onClick={dismiss}
-              disabled={phase === "applying"}
-              className="flex-1 rounded-md bg-app-bg-tertiary py-1.5 text-[11px] font-semibold text-app-text-secondary transition-colors hover:bg-app-border-primary disabled:opacity-60"
-            >
-              Dismiss
-            </button>
-          </div>
+      <div className="rounded-[10px] border border-app-border-primary bg-app-bg-secondary p-3">
+        <div className="text-[10px] font-bold uppercase tracking-[0.5px] text-app-text-muted">
+          Version
         </div>
-      )}
 
-      {phase === "restart-prompt" && (
+        {version?.current ? (
+          <>
+            <p className="mt-2 text-[11px] text-white">
+              Running <span className="font-mono font-semibold">{version.current.commit}</span>
+              {currentRunningFor ? ` for ${currentRunningFor}` : ""}
+            </p>
+
+            {version.previous ? (
+              !rollbackConfirming ? (
+                <button
+                  onClick={() => setRollbackConfirming(true)}
+                  className="mt-2 flex w-full items-center justify-center gap-2 rounded-md bg-app-bg-tertiary py-2 text-[12px] font-semibold text-white transition-colors hover:bg-app-border-primary"
+                >
+                  Roll back to <span className="font-mono">{version.previous.commit}</span>
+                </button>
+              ) : (
+                <div className="mt-2 rounded-md border border-app-orange/40 bg-app-orange/10 p-2.5">
+                  <p className="text-[11px] font-semibold text-white">
+                    Roll back to <span className="font-mono">{version.previous.commit}</span>
+                    {previousRanFor ? ` (ran for ${previousRanFor}` : ""}
+                    {previousRanFor ? `, until ${formatDate(version.current.appliedAt)})` : ""}?
+                  </p>
+                  <p className="mt-1.5 text-[10px] text-app-text-muted">
+                    Note: if this device auto-updates monthly from the same branch, next month's
+                    check may fast-forward right back onto the commit you're rolling back from.
+                  </p>
+                  <div className="mt-2 flex gap-2">
+                    <button
+                      onClick={handleRollback}
+                      disabled={rollingBack}
+                      className="flex-1 rounded-md bg-app-orange py-1.5 text-[11px] font-bold uppercase tracking-wide text-white transition-opacity hover:opacity-90 disabled:opacity-60"
+                    >
+                      {rollingBack ? "Rolling back…" : "Roll Back"}
+                    </button>
+                    <button
+                      onClick={() => setRollbackConfirming(false)}
+                      disabled={rollingBack}
+                      className="flex-1 rounded-md bg-app-bg-tertiary py-1.5 text-[11px] font-semibold text-app-text-secondary transition-colors hover:bg-app-border-primary disabled:opacity-60"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )
+            ) : (
+              <p className="mt-2 text-[10px] text-app-text-muted">
+                No previous version recorded yet.
+              </p>
+            )}
+          </>
+        ) : (
+          <p className="mt-2 text-[10px] text-app-text-muted">
+            {versionLoading ? "Loading…" : "Version info unavailable."}
+          </p>
+        )}
+      </div>
+
+      {restartPromptVisible && (
         <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 p-4">
           <div className="w-full max-w-[360px] rounded-xl border border-app-border-primary bg-app-bg-secondary p-4 shadow-2xl">
             <p className="text-[13px] font-bold text-white">Update installed</p>
@@ -156,10 +314,7 @@ export default function UpdatePanel() {
                 {restarting ? "Restarting…" : "Restart"}
               </button>
               <button
-                onClick={() => {
-                  setCheck(null);
-                  setPhase("idle");
-                }}
+                onClick={() => setRestartPromptVisible(false)}
                 disabled={restarting}
                 className="flex-1 rounded-md bg-app-bg-tertiary py-2 text-[12px] font-semibold text-app-text-secondary transition-colors hover:bg-app-border-primary disabled:opacity-60"
               >
@@ -169,6 +324,6 @@ export default function UpdatePanel() {
           </div>
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/front/plant-imaging-controller-faa-main/client/lib/api.ts
+++ b/front/plant-imaging-controller-faa-main/client/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   SystemInfo,
   UpdateApplyResult,
   UpdateCheckResult,
+  VersionStatus,
 } from "@shared/api";
 
 async function errorDetail(res: Response): Promise<string> {
@@ -60,6 +61,8 @@ export const api = {
   restartService: () => jsonFetch<{ status: string }>("/api/system/restart-service", { method: "POST" }),
   checkForUpdate: () => jsonFetch<UpdateCheckResult>("/api/system/update/check"),
   applyUpdate: () => jsonFetch<UpdateApplyResult>("/api/system/update/apply", { method: "POST" }),
+  versionStatus: () => jsonFetch<VersionStatus>("/api/system/update/version"),
+  rollbackUpdate: () => jsonFetch<UpdateApplyResult>("/api/system/update/rollback", { method: "POST" }),
   testPhotoWithSettings: async (settings: CameraSettings): Promise<Blob> => {
     const res = await fetch("/api/preview/test-photo", {
       method: "POST",

--- a/front/plant-imaging-controller-faa-main/client/pages/ExperimentSummary.tsx
+++ b/front/plant-imaging-controller-faa-main/client/pages/ExperimentSummary.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { Power } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { formatElapsed } from "@/lib/progress";
 import type { ImageInfo } from "@shared/api";
 
 export default function ExperimentSummary() {
@@ -48,13 +49,6 @@ export default function ExperimentSummary() {
     return `${system.storageRoot}/${experimentId}`;
   }, [system?.storageRoot, experimentId]);
 
-  const formatTime = (seconds: number) => {
-    const hours = Math.floor(seconds / 3600);
-    const minutes = Math.floor((seconds % 3600) / 60);
-    const secs = seconds % 60;
-    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
-  };
-
   const handleClose = () => {
     // Do NOT restart the backend here. Killing uvicorn while the kiosk holds
     // WebSocket / MJPEG connections hangs the UI on "Restarting…" forever.
@@ -81,7 +75,7 @@ export default function ExperimentSummary() {
           <div className="rounded-[10px] border border-app-border-primary bg-app-bg-secondary p-2 text-center">
             <div className="text-app-text-muted text-[10px] font-bold uppercase">Total Time</div>
             <div className="text-[22px] font-black text-app-green tabular-nums leading-7">
-              {formatTime(elapsed)}
+              {formatElapsed(elapsed)}
             </div>
           </div>
           <div className="rounded-[10px] border border-app-border-primary bg-app-bg-secondary p-2 text-center">

--- a/front/plant-imaging-controller-faa-main/client/pages/ProgressGrowth.tsx
+++ b/front/plant-imaging-controller-faa-main/client/pages/ProgressGrowth.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Folder, Home, Pause, Play, Square, X } from "lucide-react";
 import { api } from "@/lib/api";
 import { useExperimentStatus } from "@/hooks/useExperimentStatus";
+import { formatElapsed } from "@/lib/progress";
 import type { ExperimentPhase } from "@shared/api";
 
 const PHASE_LABEL: Partial<Record<ExperimentPhase, string>> = {
@@ -10,14 +11,6 @@ const PHASE_LABEL: Partial<Record<ExperimentPhase, string>> = {
   day: "Day (lit)",
   night: "Night (dark)",
 };
-
-function formatTime(seconds: number) {
-  const s = Math.max(0, Math.floor(seconds));
-  const h = Math.floor(s / 3600);
-  const m = Math.floor((s % 3600) / 60);
-  const sec = s % 60;
-  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
-}
 
 export default function ProgressGrowth() {
   const navigate = useNavigate();
@@ -148,7 +141,7 @@ export default function ProgressGrowth() {
           {/* Info panel */}
           <div className="flex flex-col gap-2 flex-shrink-0 w-36">
             <div className="bg-app-bg-secondary border border-app-border-primary rounded-lg p-3 text-center">
-              <div className="text-2xl font-black text-app-green tabular-nums">{formatTime(elapsed)}</div>
+              <div className="text-2xl font-black text-app-green tabular-nums">{formatElapsed(elapsed)}</div>
               <p className="text-app-text-muted text-[10px] mt-1">Elapsed</p>
             </div>
 

--- a/front/plant-imaging-controller-faa-main/client/pages/ProgressTropism.tsx
+++ b/front/plant-imaging-controller-faa-main/client/pages/ProgressTropism.tsx
@@ -3,20 +3,13 @@ import { useNavigate } from "react-router-dom";
 import { Folder, Home, Pause, Play, Square, X } from "lucide-react";
 import { api } from "@/lib/api";
 import { useExperimentStatus } from "@/hooks/useExperimentStatus";
+import { formatElapsed } from "@/lib/progress";
 import type { ExperimentPhase } from "@shared/api";
 
 const PHASE_LABEL: Partial<Record<ExperimentPhase, string>> = {
   dark: "Dark (apical hook)",
   bending: "Bending (lateral light)",
 };
-
-function formatTime(seconds: number) {
-  const s = Math.max(0, Math.floor(seconds));
-  const h = Math.floor(s / 3600);
-  const m = Math.floor((s % 3600) / 60);
-  const sec = s % 60;
-  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
-}
 
 export default function ProgressTropism() {
   const navigate = useNavigate();
@@ -143,7 +136,7 @@ export default function ProgressTropism() {
           {/* Info panel */}
           <div className="flex flex-col gap-2 flex-shrink-0 w-36">
             <div className="bg-app-bg-secondary border border-app-border-primary rounded-lg p-3 text-center">
-              <div className="text-2xl font-black text-app-green tabular-nums">{formatTime(elapsed)}</div>
+              <div className="text-2xl font-black text-app-green tabular-nums">{formatElapsed(elapsed)}</div>
               <p className="text-app-text-muted text-[10px] mt-1">Elapsed</p>
             </div>
 

--- a/front/plant-imaging-controller-faa-main/shared/api.ts
+++ b/front/plant-imaging-controller-faa-main/shared/api.ts
@@ -105,6 +105,10 @@ export interface SystemInfo {
   diskFreeBytes: number;
   diskTotalBytes: number;
   cameraAvailable: boolean;
+  // Settings -> General -> SSH Access. Build the full command client-side
+  // (`ssh ${sshUser}@${ip}`) -- `ip` above is the one source of truth.
+  sshUser: string;
+  sshEnabled: boolean;
 }
 
 // OTA self-update (Settings -> General -> Update button).

--- a/front/plant-imaging-controller-faa-main/shared/api.ts
+++ b/front/plant-imaging-controller-faa-main/shared/api.ts
@@ -119,15 +119,35 @@ export interface UpdateCheckResult {
 }
 
 export interface UpdateApplyResult {
-  status: "updated" | "up_to_date" | "error" | "experiment_active";
+  status:
+    | "updated"
+    | "up_to_date"
+    | "error"
+    | "experiment_active"
+    | "rolled_back"
+    | "nothing_to_roll_back_to";
   message: string;
   fromCommit: string | null;
   toCommit: string | null;
-  // Set only when status === "updated". "failed" means the pull itself
-  // succeeded but the post-pull dependency/build step did not -- code and
-  // installed deps are now mismatched, a worse state than a clean refusal.
+  // Set only when status is "updated" or "rolled_back". "failed" means the
+  // git move succeeded but the post-move dependency/build step did not --
+  // code and installed deps are now mismatched, a worse state than a clean
+  // refusal.
   rebuildStatus: "skipped" | "ok" | "failed" | null;
   rebuildMessage: string | null;
+}
+
+// One row in the OTA update history (Settings -> General -> Version).
+export interface UpdateHistoryEntry {
+  commit: string;
+  appliedAt: string; // ISO 8601
+  trigger: "manual" | "monthly" | "rollback" | "seed";
+}
+
+export interface VersionStatus {
+  current: UpdateHistoryEntry | null;
+  previous: UpdateHistoryEntry | null;
+  error: string | null;
 }
 
 export interface CameraSettings {


### PR DESCRIPTION
Three independent, separately-committed pieces of Settings -> General polish, built on top of #9's OTA update foundation.

**Version history + rollback** (`6914601`)
- Every successful update now records commit + timestamp + trigger in a small JSON history file.
- New "Version" card shows the current commit and how long it's been running, with a "Roll back to <hash>" button once a previous version is recorded.
- Rollback uses `git checkout --detach`, not `git reset --hard` -- keeps the branch ref untouched so a later fast-forward apply (including the unattended monthly one) can't silently re-apply the commit you just rolled back from. Refuses on a dirty tree or an active experiment, same as apply.
- UI carries an explicit warning that a rollback isn't permanent protection against the monthly auto-update eventually catching back up to that commit.

**SSH info card** (`f2b18cd`)
- Shows the SSH username (read from the running process's own uid, so it matches what SSH would actually log into), live enabled/active status (`systemctl is-active ssh`), and an explicit `ssh user@ip` command.

**Float-precision bug fix** (`6b72ed9`)
- Found the actual bug: `ExperimentSummary.tsx` had its own copy of the elapsed-time formatter missing the `Math.floor` the other two copies had, so a value like `142.38199999999998` rendered as `00:02:22.381999999999977` in the "Total Time" stat.
- Consolidated all three near-duplicate formatters onto the one already-correct shared helper.

79 backend tests pass; `npm run typecheck`/`npm run build` pass.